### PR TITLE
use phys_footprint to get instruments memory usage

### DIFF
--- a/DoraemonKit/Src/Core/Plugin/Memory/Function/DoraemonMemoryUtil.m
+++ b/DoraemonKit/Src/Core/Plugin/Memory/Function/DoraemonMemoryUtil.m
@@ -10,14 +10,15 @@
 
 @implementation DoraemonMemoryUtil
 
+//instruments memory usage in megabytes
 + (NSUInteger)useMemoryForApp{
-    struct mach_task_basic_info info;
-    mach_msg_type_number_t count = MACH_TASK_BASIC_INFO_COUNT;
-    
-    int r = task_info(mach_task_self(), MACH_TASK_BASIC_INFO, (task_info_t)& info, & count);
-    if (r == KERN_SUCCESS)
+    task_vm_info_data_t vmInfo;
+    mach_msg_type_number_t count = TASK_VM_INFO_COUNT;
+    kern_return_t kernelReturn = task_info(mach_task_self(), TASK_VM_INFO, (task_info_t) &vmInfo, &count);
+    if(kernelReturn == KERN_SUCCESS)
     {
-        return info.resident_size/1024/1024;
+        int64_t memoryUsageInByte = (int64_t) vmInfo.phys_footprint;
+        return memoryUsageInByte/1024/1024;
     }
     else
     {


### PR DESCRIPTION
reference: 

1. https://github.com/aozhimin/iOS-Monitor-Platform/issues/14
2. http://www.samirchen.com/ios-app-memory-usage/