### PR TITLE
UI元素辅助线功能遗漏对UIStatusBarWindow判断的修复

### DIFF
--- a/iOS/DoraemonKit/Src/Core/Plugin/ViewMetrics/Function/DoraemonViewMetricsConfig.m
+++ b/iOS/DoraemonKit/Src/Core/Plugin/ViewMetrics/Function/DoraemonViewMetricsConfig.m
@@ -45,6 +45,16 @@
             [window hideDoraemonMetricsRecursive];
         }
     }
+    
+    // 每当状态栏发生变化（如: 时间跳动，4G切WIFI，横竖屏切换等），状态栏会走`layoutSubviews`方法，会导致状态栏也出现元素边框；而[UIApplication sharedApplication].windows数组内拿不到UIStatusBarWindow，关闭元素边框无法及时隐藏状态栏的边框线
+    // 也可以在`UIView+DoraemonViewMetrics.h`内的`shouldShowMetricsView`中直接禁掉状态栏的元素边框
+    NSString *statusBarString = [NSString stringWithFormat:@"_statusBarWindow"];
+    UIWindow *statusBarWindow = [[UIApplication sharedApplication] valueForKey:statusBarString];
+    if (statusBarWindow) {
+        if (!enable) {
+            [statusBarWindow hideDoraemonMetricsRecursive];
+        }
+    }
 }
 
 @end

--- a/iOS/DoraemonKit/Src/Core/Plugin/ViewMetrics/Function/UIView+DoraemonViewMetrics.m
+++ b/iOS/DoraemonKit/Src/Core/Plugin/ViewMetrics/Function/UIView+DoraemonViewMetrics.m
@@ -32,6 +32,13 @@
         return NO;
     }
     
+    // 状态栏不需要显示元素边框
+    NSString *statusBarString = [NSString stringWithFormat:@"_statusBarWindow"];
+    UIWindow *statusBarWindow = [[UIApplication sharedApplication] valueForKey:statusBarString];
+    if (statusBarWindow && [self isDescendantOfView:statusBarWindow]) {
+        return NO;
+    }
+    
     if ([self isInBlackList]) {
         return NO;
     }


### PR DESCRIPTION
参见issue：[iOS 『元素边框线』对于UIStatusBarWindow的遗漏](https://github.com/didi/DoraemonKit/issues/30)