### PR TITLE
fix:在iOS9.0系统中直接不显示状态栏的问题，但是在开启cpu监听等状态时，还是不显示状态栏，暂未找到解决版本

### DIFF
--- a/iOS/DoraemonKit/Src/Core/Base/DoraemonStatusBarViewController.h
+++ b/iOS/DoraemonKit/Src/Core/Base/DoraemonStatusBarViewController.h
@@ -1,0 +1,16 @@
+//
+//  DoraemonStatusBarViewController.h
+//  AFNetworking
+//
+//  Created by 张伟 on 2019/2/22.
+//
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface DoraemonStatusBarViewController : UIViewController
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/iOS/DoraemonKit/Src/Core/Base/DoraemonStatusBarViewController.m
+++ b/iOS/DoraemonKit/Src/Core/Base/DoraemonStatusBarViewController.m
@@ -1,0 +1,38 @@
+//
+//  DoraemonStatusBarViewController.m
+//  AFNetworking
+//
+//  Created by 张伟 on 2019/2/22.
+//
+
+#import "DoraemonStatusBarViewController.h"
+
+@interface DoraemonStatusBarViewController ()
+
+@end
+
+@implementation DoraemonStatusBarViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    // Do any additional setup after loading the view.
+}
+- (BOOL)prefersStatusBarHidden
+{
+    return NO;
+}
+- (UIStatusBarStyle)preferredStatusBarStyle
+{
+    return UIStatusBarStyleDefault;
+}
+/*
+#pragma mark - Navigation
+
+// In a storyboard-based application, you will often want to do a little preparation before navigation
+- (void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender {
+    // Get the new view controller using [segue destinationViewController].
+    // Pass the selected object to the new view controller.
+}
+*/
+
+@end

--- a/iOS/DoraemonKit/Src/Core/Entry/DoraemonEntryView.m
+++ b/iOS/DoraemonKit/Src/Core/Entry/DoraemonEntryView.m
@@ -13,7 +13,7 @@
 #import "UIImage+Doraemon.h"
 #import "DoraemonDefine.h"
 #import "DoraemonHomeWindow.h"
-
+#import "DoraemonStatusBarViewController.h"
 @interface DoraemonEntryView()
 
 @property (nonatomic, assign) BOOL isOpen;
@@ -32,8 +32,15 @@
         
         self.backgroundColor = [UIColor clearColor];
         self.windowLevel = UIWindowLevelStatusBar + 100.f;
-        if (!self.rootViewController) {
-            self.rootViewController = [[UIViewController alloc] init];
+        NSString *version= [UIDevice currentDevice].systemVersion;
+        if(version.doubleValue >=10.0) {
+            if (!self.rootViewController) {
+                self.rootViewController = [[UIViewController alloc] init];
+            }
+        }else{
+            if (!self.rootViewController) {
+                self.rootViewController = [[DoraemonStatusBarViewController alloc] init];
+            }
         }
         
         UIButton *entryBtn = [[UIButton alloc] initWithFrame:self.bounds];


### PR DESCRIPTION
主要问题在iOS9.0的系统中，新建的window设置的rootViewController默认没有显示状态栏，我在DoraemonEntryView里面加了个判断，但是还有发现的已知问题没有解决，如果开启帧率或者cpu检查等功能，状态栏还是没有没有显示，目前这样至少保证了关闭所有功能之后能够显示正常，剩下的问题还需要花时间去找原因