### PR TITLE
fix(OkHttpAspect):OkHttp添加日志拦截去除依赖流量监测开关

### DIFF
--- a/Android/app/src/main/java/com/didichuxing/doraemondemo/MainActivity.java
+++ b/Android/app/src/main/java/com/didichuxing/doraemondemo/MainActivity.java
@@ -34,6 +34,7 @@ import okhttp3.Response;
 public class MainActivity extends AppCompatActivity implements View.OnClickListener {
 
 
+    private OkHttpClient okHttpClient;
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -44,6 +45,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         findViewById(R.id.btn_test_crash).setOnClickListener(this);
         findViewById(R.id.btn_show_hide_icon).setOnClickListener(this);
         findViewById(R.id.btn_time_count).setOnClickListener(this);
+        okHttpClient = new OkHttpClient().newBuilder().build();
     }
 
     @Override
@@ -178,10 +180,9 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
     }
 
     public void requestByOkHttp() {
-        OkHttpClient client = new OkHttpClient().newBuilder().build();
         Request request = new Request.Builder().get().url("http://www.roundsapp.com/post")
                 .addHeader("testHead", "hahahah").build();
-        Call call = client.newCall(request);
+        Call call = okHttpClient.newCall(request);
         //异步调用并设置回调函数
         call.enqueue(new Callback() {
             @Override

--- a/Android/doraemonkit/src/main/java/com/didichuxing/doraemonkit/kit/network/aspect/AopUtils.java
+++ b/Android/doraemonkit/src/main/java/com/didichuxing/doraemonkit/kit/network/aspect/AopUtils.java
@@ -30,8 +30,6 @@ public class AopUtils {
     }
 
     public static void addInterceptor(OkHttpClient.Builder builder){
-        if (NetworkManager.isActive()) {
-            builder.addInterceptor(new DoraemonInterceptor());
-        }
+        builder.addInterceptor(new DoraemonInterceptor());
     }
 }


### PR DESCRIPTION
OkHttp添加日志拦截去除依赖流量监测开关，因为在实际场景中，OkHttpClient只会创建一次，当打开流量日志开关的时候，OkHttpClient已经创建过了，不会走Builder.build因此拦截不到