### PR TITLE
【修复】#196 在Android设备上浏览数据库表的时候，带有BLOB类型的不能浏览

### DIFF
--- a/Android/doraemonkit/src/main/java/com/didichuxing/doraemonkit/util/DatabaseUtil.java
+++ b/Android/doraemonkit/src/main/java/com/didichuxing/doraemonkit/util/DatabaseUtil.java
@@ -43,7 +43,11 @@ public class DatabaseUtil {
         for (int y = 0; y <rowCount; y++) {
             if (cursor.moveToNext()) {
                 for (int x = 0; x < strings.length; x++) {
-                    words[x][y] = cursor.getString(x);
+                    if (cursor.getType(x) == Cursor.FIELD_TYPE_BLOB) {
+                        words[x][y] = new String(cursor.getBlob(x));
+                    } else {
+                        words[x][y] = cursor.getString(x);
+                    }
                 }
             }
         }


### PR DESCRIPTION
DatabaseDetailFragment 展示本地sqlite文件内容，如果column类型是FIELD_TYPE_BLOB，调用Cursor.getString()会直接报错，建议先通过cursor.getType()先判断column类型，再调用cursor.getString()或者cursor.getBlob() 取值。