### PR TITLE
修复帧率Fragment 不能保存数据问题

### DIFF
--- a/Android/doraemonkit/src/main/java/com/didichuxing/doraemonkit/kit/parameter/frameInfo/FrameInfoFragment.java
+++ b/Android/doraemonkit/src/main/java/com/didichuxing/doraemonkit/kit/parameter/frameInfo/FrameInfoFragment.java
@@ -1,18 +1,17 @@
 package com.didichuxing.doraemonkit.kit.parameter.frameInfo;
 
 import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.view.View;
-
 import com.didichuxing.doraemonkit.R;
-import com.didichuxing.doraemonkit.config.PerformanceInfoConfig;
 import com.didichuxing.doraemonkit.constant.BundleKey;
-import com.didichuxing.doraemonkit.kit.parameter.AbsParameterFragment;
 import com.didichuxing.doraemonkit.kit.common.PerformanceDataManager;
 import com.didichuxing.doraemonkit.kit.common.PerformanceFragment;
+import com.didichuxing.doraemonkit.kit.parameter.AbsParameterFragment;
 import com.didichuxing.doraemonkit.ui.realtime.datasource.DataSourceFactory;
 import com.didichuxing.doraemonkit.ui.setting.SettingItem;
 import com.didichuxing.doraemonkit.ui.setting.SettingItemAdapter;
-
 import java.util.Collection;
 import java.util.List;
 
@@ -21,6 +20,12 @@ import java.util.List;
  */
 
 public class FrameInfoFragment extends AbsParameterFragment {
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+        PerformanceDataManager.getInstance().init(getContext().getApplicationContext());
+    }
 
     @Override
     protected int getTitle() {


### PR DESCRIPTION
如果之前没有点进去过CPU,RAM页面，帧率显示页面将不能保存帧率数据，原因在于帧率页面没有初始化`PerformanceDataManager `,所以在帧率页面加上了初始化操作