### PR TITLE
FIX : build error without gps subspec installed

### DIFF
--- a/iOS/DoraemonKit/Src/Core/Manager/DoraemonManager.m
+++ b/iOS/DoraemonKit/Src/Core/Manager/DoraemonManager.m
@@ -116,7 +116,7 @@ typedef void (^DoraemonPerformanceBlock)(NSDictionary *);
     [[DoraemonCacheManager sharedInstance] saveMemorySwitch:NO];
     [[DoraemonCacheManager sharedInstance] saveNetFlowSwitch:NO];
     
-    
+#if DoraemonWithGPS
     //开启mockGPS功能
     if ([[DoraemonCacheManager sharedInstance] mockGPSSwitch]) {
         CLLocationCoordinate2D coordinate = [[DoraemonCacheManager sharedInstance] mockCoordinate];
@@ -125,7 +125,7 @@ typedef void (^DoraemonPerformanceBlock)(NSDictionary *);
             [[DoraemonGPSMocker shareInstance] mockPoint:loc];
         }
     }
-
+#endif
     
     //开启NSLog监控功能
     if ([[DoraemonCacheManager sharedInstance] nsLogSwitch]) {


### PR DESCRIPTION
`#import "DoraemonGPSMocker.h"` is enclosed with `DoraemonWithGPS` define check:
```objc
#if DoraemonWithGPS
#import "DoraemonGPSMocker.h"
#endif
```

 but the usage of `DoraemonGPSMocker` in line 126 is not checked with `DoraemonWithGPS` definition, which may cause build error without `DoraemonKit/WithGPS` integrated.

```objc
[[DoraemonCacheManager sharedInstance] saveMemorySwitch:NO];
[[DoraemonCacheManager sharedInstance] saveNetFlowSwitch:NO];


//开启mockGPS功能
if ([[DoraemonCacheManager sharedInstance] mockGPSSwitch]) {
    CLLocationCoordinate2D coordinate = [[DoraemonCacheManager sharedInstance] mockCoordinate];
    if (coordinate.longitude>0 && coordinate.latitude>0) {
        CLLocation *loc = [[CLLocation alloc] initWithLatitude:coordinate.latitude longitude:coordinate.longitude];
        [[DoraemonGPSMocker shareInstance] mockPoint:loc];  // <---- here
    }
}


//开启NSLog监控功能
if ([[DoraemonCacheManager sharedInstance] nsLogSwitch]) {
```