### PR TITLE
fix(流量监控):Android-解决流量监控打开崩溃的异常

### DIFF
--- a/Android/doraemonkit/src/main/java/com/didichuxing/doraemonkit/ui/realtime/RealTimeChartIconPage.java
+++ b/Android/doraemonkit/src/main/java/com/didichuxing/doraemonkit/ui/realtime/RealTimeChartIconPage.java
@@ -41,7 +41,7 @@ public class RealTimeChartIconPage extends BaseFloatPage implements View.OnClick
     @Override
     protected void onCreate(Context context) {
         super.onCreate(context);
-        PerformanceDataManager.getInstance().init(getContext());
+        PerformanceDataManager.getInstance().init(context);
     }
 
     @Override


### PR DESCRIPTION
RealTimeChartIconPage 在onCreate回调时, 调用 getContext只会得到null，导致NPE;

因为getContext()的实现为
`    public Context getContext() {
        if (mRootView != null) {
            return mRootView.getContext();
        } else {
            return null;
        }
    }`
而此时,view还未创建