### PR TITLE
fix(模拟弱网):解决由于BufferedSink已被close 后再次读取时导致的IllegalState异常

### DIFF
--- a/Android/doraemonkit/src/main/java/com/didichuxing/doraemonkit/kit/weaknetwork/SpeedLimitRequestBody.java
+++ b/Android/doraemonkit/src/main/java/com/didichuxing/doraemonkit/kit/weaknetwork/SpeedLimitRequestBody.java
@@ -37,13 +37,16 @@ public class SpeedLimitRequestBody extends RequestBody {
 
     @Override
     public void writeTo(BufferedSink sink) throws IOException {
+        //该requestBody的 writeTo方法第一次被调用时，包装成ByteCountBufferedSink 控制读取速度
         if (mBufferedSink == null) {
             //mBufferedSink = Okio.buffer(sink(sink));
             //默认8K 精确到1K
             mBufferedSink = new ByteCountBufferedSink(sink(sink), 1024L);
+            mRequestBody.writeTo(mBufferedSink);
+        } else {
+            //该requestBody的 writeTo方法非第一次调用时 正常读取
+            mRequestBody.writeTo(sink);
         }
-        mRequestBody.writeTo(mBufferedSink);
-        mBufferedSink.close();
     }
 
     private Sink sink(final BufferedSink sink) {


### PR DESCRIPTION
解决由于BufferedSink已被close 后再次读取时导致的IllegalState异常

我们的项目中也添加了Interceptor 并且调用了 RequestBody 的WriteTo方法，由于Doraemonkit提前调用close()方法 ，导致我们项目自定义的Interceptor 读取时抛出 java.lang.IllegalStateException: closed 异常

BufferedSink 会由OkHttp 在 CallServerInterceptor 处理时调用close 释放资源, 不需要主动调用close方法。
