### PR TITLE
fix: 性能检测： 帧率、CPU、内存、流量页面打开时关闭悬浮窗后 UISwitch 按钮状态未改变问题

### DIFF
--- a/iOS/DoraemonKit/Src/Core/CommonUI/Oscillogram/DoraemonOscillogramWindow.h
+++ b/iOS/DoraemonKit/Src/Core/CommonUI/Oscillogram/DoraemonOscillogramWindow.h
@@ -6,7 +6,14 @@
 //
 
 #import <UIKit/UIKit.h>
+#import <Foundation/Foundation.h>
 #import "DoraemonOscillogramViewController.h"
+
+@protocol DoraemonOscillogramWindowDelegate <NSObject>
+
+- (void)doraemonOscillogramWindowClosed;
+
+@end
 
 @interface DoraemonOscillogramWindow : UIWindow
 
@@ -20,5 +27,9 @@
 - (void)show;
 
 - (void)hide;
+
+- (void)addDelegate:(id<DoraemonOscillogramWindowDelegate>) delegate;
+
+- (void)removeDelegate:(id<DoraemonOscillogramWindowDelegate>)delegate;
 
 @end

--- a/iOS/DoraemonKit/Src/Core/CommonUI/Oscillogram/DoraemonOscillogramWindow.m
+++ b/iOS/DoraemonKit/Src/Core/CommonUI/Oscillogram/DoraemonOscillogramWindow.m
@@ -13,9 +13,26 @@
 
 @interface DoraemonOscillogramWindow()
 
+@property (nonatomic, strong) NSHashTable *delegates;
+
 @end
 
 @implementation DoraemonOscillogramWindow
+
+- (NSHashTable *)delegates {
+    if (_delegates == nil) {
+        self.delegates = [NSHashTable weakObjectsHashTable];
+    }
+    return _delegates;
+}
+
+- (void)addDelegate:(id<DoraemonOscillogramWindowDelegate>) delegate {
+    [self.delegates addObject:delegate];
+}
+
+- (void)removeDelegate:(id<DoraemonOscillogramWindowDelegate>)delegate {
+    [self.delegates removeObject:delegate];
+}
 
 + (DoraemonOscillogramWindow *)shareInstance{
     static dispatch_once_t once;
@@ -65,6 +82,10 @@
     [_vc endRecord];
     self.hidden = YES;
     [self resetLayout];
+    
+    for (id<DoraemonOscillogramWindowDelegate> delegate in self.delegates) {
+        [delegate doraemonOscillogramWindowClosed];
+    }
 }
 
 - (void)resetLayout{

--- a/iOS/DoraemonKit/Src/Core/Plugin/CPU/DoraemonCPUViewController.m
+++ b/iOS/DoraemonKit/Src/Core/Plugin/CPU/DoraemonCPUViewController.m
@@ -13,7 +13,7 @@
 #import "DoraemonCellSwitch.h"
 #import "DoraemonDefine.h"
 
-@interface DoraemonCPUViewController ()<DoraemonSwitchViewDelegate>
+@interface DoraemonCPUViewController ()<DoraemonSwitchViewDelegate, DoraemonOscillogramWindowDelegate>
 
 @property (nonatomic, strong) DoraemonCellSwitch *switchView;
 
@@ -31,6 +31,7 @@
     [_switchView needDownLine];
     _switchView.delegate = self;
     [self.view addSubview:_switchView];
+    [[DoraemonCPUOscillogramWindow shareInstance] addDelegate:self];
 }
 
 - (BOOL)needBigTitleView{
@@ -45,6 +46,11 @@
     }else{
         [[DoraemonCPUOscillogramWindow shareInstance] hide];
     }
+}
+
+#pragma mark -- DoraemonOscillogramWindowDelegate
+- (void)doraemonOscillogramWindowClosed {
+    [_switchView renderUIWithTitle:DoraemonLocalizedString(@"CPU检测开关") switchOn:[[DoraemonCacheManager sharedInstance] cpuSwitch]];
 }
 
 @end

--- a/iOS/DoraemonKit/Src/Core/Plugin/FPS/DoraemonFPSViewController.m
+++ b/iOS/DoraemonKit/Src/Core/Plugin/FPS/DoraemonFPSViewController.m
@@ -12,7 +12,7 @@
 #import "DoraemonCellSwitch.h"
 #import "DoraemonDefine.h"
 
-@interface DoraemonFPSViewController ()<DoraemonSwitchViewDelegate>
+@interface DoraemonFPSViewController ()<DoraemonSwitchViewDelegate, DoraemonOscillogramWindowDelegate>
 
 @property (nonatomic, strong) DoraemonCellSwitch *switchView;
 
@@ -30,6 +30,7 @@
     [_switchView needDownLine];
     _switchView.delegate = self;
     [self.view addSubview:_switchView];
+    [[DoraemonFPSOscillogramWindow shareInstance] addDelegate:self];
 }
 
 
@@ -46,6 +47,11 @@
     }else{
         [[DoraemonFPSOscillogramWindow shareInstance] hide];
     }
+}
+
+#pragma mark -- DoraemonOscillogramWindowDelegate
+- (void)doraemonOscillogramWindowClosed {
+    [_switchView renderUIWithTitle:DoraemonLocalizedString(@"帧率检测开关") switchOn:[[DoraemonCacheManager sharedInstance] fpsSwitch]];
 }
 
 @end

--- a/iOS/DoraemonKit/Src/Core/Plugin/Memory/DoraemonMemoryViewController.m
+++ b/iOS/DoraemonKit/Src/Core/Plugin/Memory/DoraemonMemoryViewController.m
@@ -12,7 +12,7 @@
 #import "DoraemonCellSwitch.h"
 #import "DoraemonDefine.h"
 
-@interface DoraemonMemoryViewController ()<DoraemonSwitchViewDelegate>
+@interface DoraemonMemoryViewController ()<DoraemonSwitchViewDelegate, DoraemonOscillogramWindowDelegate>
 
 @property (nonatomic, strong) DoraemonCellSwitch *switchView;
 
@@ -30,6 +30,7 @@
     [_switchView needDownLine];
     _switchView.delegate = self;
     [self.view addSubview:_switchView];
+    [[DoraemonMemoryOscillogramWindow shareInstance] addDelegate:self];
 }
 
 - (BOOL)needBigTitleView{
@@ -44,6 +45,11 @@
     }else{
         [[DoraemonMemoryOscillogramWindow shareInstance] hide];
     }
+}
+
+#pragma mark -- DoraemonOscillogramWindowDelegate
+- (void)doraemonOscillogramWindowClosed {
+    [_switchView renderUIWithTitle:DoraemonLocalizedString(@"内存检测开关") switchOn:[[DoraemonCacheManager sharedInstance] memorySwitch]];
 }
 
 @end

--- a/iOS/DoraemonKit/Src/Core/Plugin/NetFlow/DoraemonNetFlowViewController.m
+++ b/iOS/DoraemonKit/Src/Core/Plugin/NetFlow/DoraemonNetFlowViewController.m
@@ -21,7 +21,7 @@
 #import "DoraemonDefine.h"
 
 
-@interface DoraemonNetFlowViewController ()<DoraemonSwitchViewDelegate>
+@interface DoraemonNetFlowViewController ()<DoraemonSwitchViewDelegate, DoraemonOscillogramWindowDelegate>
 @property (nonatomic, strong) UITabBarController *tabBar;
 
 @property (nonatomic, strong) DoraemonCellSwitch *switchView;
@@ -33,6 +33,7 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
     [self initUI];
+    [[DoraemonNetFlowOscillogramWindow shareInstance] addDelegate:self];
 }
 
 - (void)initUI{
@@ -102,6 +103,11 @@
     tabBar.viewControllers = @[nav1,nav2];
     
     [self presentViewController:tabBar animated:YES completion:nil];
+}
+
+#pragma mark -- DoraemonOscillogramWindowDelegate
+- (void)doraemonOscillogramWindowClosed {
+    [_switchView renderUIWithTitle:DoraemonLocalizedString(@"流量检测开关") switchOn:[[DoraemonCacheManager sharedInstance] netFlowSwitch]];
 }
 
 @end


### PR DESCRIPTION
问题描述：在帧率、CPU、内存、流量页面关闭对应悬浮窗后 UISwitch 状态依然是打开状态