### PR TITLE
[iOS] 优化DoraemonAllTestManager

### DIFF
--- a/iOS/DoraemonKit/Src/Core/Manager/DoraemonManager.m
+++ b/iOS/DoraemonKit/Src/Core/Manager/DoraemonManager.m
@@ -150,10 +150,10 @@ typedef void (^DoraemonPerformanceBlock)(NSDictionary *);
             self.performanceBlock(upLoadData);
         }
         //默认实现 保存到沙盒中
-        NSString *testTime = [DoraemonUtil dateFormatTimeInterval:[upLoadData[@"testTime"] floatValue]];
+        NSString *testTimeString = upLoadData[@"testTime"];
         
         NSString *data = [DoraemonUtil dictToJsonStr:upLoadData];
-        [DoraemonUtil savePerformanceDataInFile:testTime data:data];
+        [DoraemonUtil savePerformanceDataInFile:testTimeString data:data];
     }];
     
     [[DoraemonANRManager sharedInstance] addANRBlock:^(NSDictionary *anrInfo) {

--- a/iOS/DoraemonKit/Src/Core/Plugin/AllTest/DoraemonAllTestViewController.m
+++ b/iOS/DoraemonKit/Src/Core/Plugin/AllTest/DoraemonAllTestViewController.m
@@ -95,6 +95,15 @@
             [[DoraemonAllTestManager shareInstance] startRecord];
             [weakSelf.okBtn setTitle:DoraemonLocalizedString(@"结束测试") forState:UIControlStateNormal];
         }else{
+            [DoraemonAllTestManager shareInstance].fpsSwitchOn = NO;
+            [DoraemonAllTestManager shareInstance].cpuSwitchOn = NO;
+            [DoraemonAllTestManager shareInstance].memorySwitchOn = NO;
+            [DoraemonAllTestManager shareInstance].flowSwitchOn = NO;
+            
+            _fpsSwitchView.switchView.on = NO;
+            _cpuSwitchView.switchView.on = NO;
+            _memorySwitchView.switchView.on = NO;
+            _flowSwitchView.switchView.on = NO;
             [[DoraemonAllTestManager shareInstance] endRecord];
             [weakSelf.okBtn setTitle:DoraemonLocalizedString(@"开始测试") forState:UIControlStateNormal];
             

--- a/iOS/DoraemonKit/Src/Core/Plugin/AllTest/DoraemonAllTestViewController.m
+++ b/iOS/DoraemonKit/Src/Core/Plugin/AllTest/DoraemonAllTestViewController.m
@@ -100,10 +100,10 @@
             [DoraemonAllTestManager shareInstance].memorySwitchOn = NO;
             [DoraemonAllTestManager shareInstance].flowSwitchOn = NO;
             
-            _fpsSwitchView.switchView.on = NO;
-            _cpuSwitchView.switchView.on = NO;
-            _memorySwitchView.switchView.on = NO;
-            _flowSwitchView.switchView.on = NO;
+            weakSelf.fpsSwitchView.switchView.on = NO;
+            weakSelf.cpuSwitchView.switchView.on = NO;
+            weakSelf.memorySwitchView.switchView.on = NO;
+            weakSelf.flowSwitchView.switchView.on = NO;
             [[DoraemonAllTestManager shareInstance] endRecord];
             [weakSelf.okBtn setTitle:DoraemonLocalizedString(@"开始测试") forState:UIControlStateNormal];
             

--- a/iOS/DoraemonKit/Src/Core/Plugin/AllTest/Function/DoraemonAllTestManager.h
+++ b/iOS/DoraemonKit/Src/Core/Plugin/AllTest/Function/DoraemonAllTestManager.h
@@ -13,7 +13,7 @@ typedef void (^DoraemonAllTestManagerBlock)(NSDictionary *upLoadData);
 
 + (DoraemonAllTestManager *)shareInstance;
 
-@property (nonatomic, assign) NSTimeInterval startTimeInterval;
+@property (nonatomic, strong) NSDate *startTime;
 
 @property (nonatomic, assign) BOOL fpsSwitchOn;
 @property (nonatomic, assign) BOOL cpuSwitchOn;

--- a/iOS/DoraemonKit/Src/Core/Plugin/AllTest/Function/DoraemonAllTestManager.m
+++ b/iOS/DoraemonKit/Src/Core/Plugin/AllTest/Function/DoraemonAllTestManager.m
@@ -66,7 +66,8 @@
     NSString *phoneSystem = [[UIDevice currentDevice] systemVersion];
     NSUInteger totalMemory = [DoraemonMemoryUtil totalMemoryForDevice];
     NSUInteger phoneMemory = totalMemory;//MB为单位
-    NSString *appVersion = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleVersion"];
+    NSString *appVersion = [[NSBundle mainBundle] objectForInfoDictionaryKey: @"CFBundleShortVersionString"];
+    
     NSString *appName = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleDisplayName"];
     if (!appName) {
         appName = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleName"];

--- a/iOS/DoraemonKit/Src/Core/Plugin/AllTest/Function/DoraemonAllTestManager.m
+++ b/iOS/DoraemonKit/Src/Core/Plugin/AllTest/Function/DoraemonAllTestManager.m
@@ -26,6 +26,7 @@
 
 @property (nonatomic, copy) DoraemonAllTestManagerBlock block;
 
+@property (nonatomic, strong) NSDateFormatter *dateFormatter;
 @end
 
 @implementation DoraemonAllTestManager
@@ -39,8 +40,16 @@
     return instance;
 }
 
+- (NSDateFormatter *)dateFormatter {
+    if (!_dateFormatter) {
+        _dateFormatter = [[NSDateFormatter alloc] init];
+        [_dateFormatter setDateFormat: @"yyyy-MM-dd HH:mm:ss:SSS"];
+    }
+    return _dateFormatter;
+}
+
 - (void)startRecord{
-    [DoraemonAllTestManager shareInstance].startTimeInterval = [[NSDate date] timeIntervalSince1970];
+    [DoraemonAllTestManager shareInstance].startTime = [NSDate date];
     if(!_secondTimer){
         _secondTimer = [NSTimer timerWithTimeInterval:1.0f target:self selector:@selector(doSecondFunction) userInfo:nil repeats:YES];
         [[NSRunLoop currentRunLoop] addTimer:_secondTimer forMode:NSRunLoopCommonModes];
@@ -61,7 +70,7 @@
 }
 
 - (void)upLoadData{
-    NSString *testTime = [NSString stringWithFormat:@"%f",_startTimeInterval];;
+    NSString *testTime = [self.dateFormatter stringFromDate: self.startTime];
     NSString *phoneName = [DoraemonAppInfoUtil iphoneType];
     NSString *phoneSystem = [[UIDevice currentDevice] systemVersion];
     NSUInteger totalMemory = [DoraemonMemoryUtil totalMemoryForDevice];
@@ -78,7 +87,7 @@
     NSMutableArray *flowData = [NSMutableArray array];
     for (DoraemonNetFlowHttpModel *httpModel in httpModelArray) {
         NSString *url = httpModel.url;
-        NSString *time = [NSString stringWithFormat:@"%f",httpModel.startTime];
+        NSString *time = [self.dateFormatter stringFromDate: [NSDate dateWithTimeIntervalSince1970: httpModel.startTime]];
         
         NSString *upFlow = httpModel.uploadFlow;
         NSString *downFlow = httpModel.downFlow;
@@ -129,9 +138,8 @@
 }
 
 - (void)doSecondFunction{
-    //1、获取当前时间戳
-    NSDate *now = [NSDate date];
-    NSString *timeInterval = [NSString stringWithFormat:@"%f",[now timeIntervalSince1970]];
+    //1、获取当前时间
+    NSString *timeString = [self.dateFormatter stringFromDate: [NSDate date]];
     
     //2、获取当前FPS值
     NSInteger fpsValue = -1;
@@ -162,7 +170,7 @@
     
     //6、组装commonData数据
     NSDictionary *commonItemData = @{
-                                     @"time":timeInterval,
+                                     @"time":timeString,
                                      @"fps":@(fpsValue),
                                      @"CPU":@(cpuValue),
                                      @"memory":@(memoryValue)

--- a/iOS/DoraemonKit/Src/Core/Plugin/DeleteLocalData/DoraemonDeleteLocalDataViewController.m
+++ b/iOS/DoraemonKit/Src/Core/Plugin/DeleteLocalData/DoraemonDeleteLocalDataViewController.m
@@ -63,16 +63,8 @@
     DoraemonUtil *util = [[DoraemonUtil alloc] init];
     [util getFileSizeWithPath:homeDir];
     NSInteger fileSize = util.fileSize;
-    //将文件夹大小转换为 M/KB/B
-    NSString *fileSizeStr = nil;
-    if (fileSize > 1024 * 1024){
-        fileSizeStr = [NSString stringWithFormat:@"%.2fM",fileSize / 1024.00f /1024.00f];
-    }else if (fileSize > 1024){
-        fileSizeStr = [NSString stringWithFormat:@"%.2fKB",fileSize / 1024.00f ];
-    }else{
-        fileSizeStr = [NSString stringWithFormat:@"%.2fB",fileSize / 1.00f];
-    }
-    return fileSizeStr;
+    NSString *fileSizeString = [NSByteCountFormatter stringFromByteCount:fileSize countStyle: NSByteCountFormatterCountStyleFile];
+    return fileSizeString;
 }
 
 


### PR DESCRIPTION
1. fixed: `appVersion` 取错， 之前取到的是`build number`

2.fixed. 使用NSByteCountFormatter计算文件大小，之前的数值计算有误差

3. feat: 自定义测试页面，结束测试后，刷新按钮状态，防止再次进入该页面状态错误

4. feat: `DoraemonAllTestManager` 输出的log文件中的时间戳改为格式化后的字符串，提高可读性
