### PR TITLE
OPTIMIZE：For maps where the keys are of type integer, it's typically …

### DIFF
--- a/Android/doraemonkit/src/main/java/com/didichuxing/doraemonkit/kit/logInfo/util/TagColorUtil.java
+++ b/Android/doraemonkit/src/main/java/com/didichuxing/doraemonkit/kit/logInfo/util/TagColorUtil.java
@@ -3,10 +3,8 @@ package com.didichuxing.doraemonkit.kit.logInfo.util;
 import android.content.Context;
 import android.support.v4.content.ContextCompat;
 import android.util.Log;
-
+import android.util.SparseIntArray;
 import com.didichuxing.doraemonkit.R;
-
-import java.util.HashMap;
 
 /**
  * @author: linjizong
@@ -14,10 +12,10 @@ import java.util.HashMap;
  * @desc:
  */
 public class TagColorUtil {
-    private static final HashMap<Integer, Integer> TEXT_COLOR = new HashMap<>(6);
-    private static final HashMap<Integer, Integer> TEXT_COLOR_EXPAND = new HashMap<>(6);
-    private static final HashMap<Integer, Integer> LEVEL_COLOR = new HashMap<>(6);
-    private static final HashMap<Integer, Integer> LEVEL_BG_COLOR = new HashMap<>(6);
+    private static final SparseIntArray TEXT_COLOR = new SparseIntArray(6);
+    private static final SparseIntArray TEXT_COLOR_EXPAND = new SparseIntArray(6);
+    private static final SparseIntArray LEVEL_COLOR = new SparseIntArray(6);
+    private static final SparseIntArray LEVEL_BG_COLOR = new SparseIntArray(6);
 
     static {
         TEXT_COLOR.put(Log.DEBUG, R.color.dk_color_000000);
@@ -50,7 +48,7 @@ public class TagColorUtil {
     }
 
     public static int getTextColor(Context context, int level, boolean expand) {
-        HashMap<Integer, Integer> map = expand ? TEXT_COLOR_EXPAND : TEXT_COLOR;
+        SparseIntArray map = expand ? TEXT_COLOR_EXPAND : TEXT_COLOR;
         Integer result = map.get(level);
         if (result == null) {
             result = map.get(Log.VERBOSE);

--- a/Android/doraemonkit_weex/src/main/java/com/didichuxing/doraemonkit/weex/devtool/DevToolActivity.java
+++ b/Android/doraemonkit_weex/src/main/java/com/didichuxing/doraemonkit/weex/devtool/DevToolActivity.java
@@ -90,7 +90,7 @@ public class DevToolActivity extends AppCompatActivity {
     }
 
     private void handleNoResult() {
-        Toast.makeText(getApplicationContext(), "没有扫描到任何内容>_<", Toast.LENGTH_SHORT);
+        Toast.makeText(getApplicationContext(), "没有扫描到任何内容>_<", Toast.LENGTH_SHORT).show();
         finish();
     }
 


### PR DESCRIPTION
…more efficient to use the Android SparseArray API. This check identifies scenarios where you might want to consider using SparseArray instead of HashMap for better performance.  This is particularly useful when the value types are primitives like ints, where you can use SparseIntArray and avoid auto-boxing the values from int to Integer.