### PR TITLE
增加位置模拟拦截中的判空逻辑

### DIFF
--- a/Android/doraemonkit/src/main/java/com/didichuxing/doraemonkit/kit/gpsmock/LocationHooker.java
+++ b/Android/doraemonkit/src/main/java/com/didichuxing/doraemonkit/kit/gpsmock/LocationHooker.java
@@ -73,6 +73,10 @@ public class LocationHooker extends BaseServiceHooker {
                 return method.invoke(originService, args);
             }
             Location lastKnownLocation = (Location) method.invoke(originService, args);
+            if (lastKnownLocation == null) {
+                LogHelper.d(TAG, "onInvoke:lastKnownLocation == null ");
+                lastKnownLocation = new Location("gps");
+            }
             lastKnownLocation.setLongitude(GpsMockManager.getInstance().getLongitude());
             lastKnownLocation.setLatitude(GpsMockManager.getInstance().getLatitude());
             lastKnownLocation.setTime(System.currentTimeMillis());
@@ -92,6 +96,10 @@ public class LocationHooker extends BaseServiceHooker {
                 return method.invoke(originService, args);
             }
             Location lastLocation = (Location) method.invoke(originService, args);
+            if (lastLocation == null) {
+                LogHelper.d(TAG, "onInvoke:lastLocation == null ");
+                lastLocation = new Location("gps");
+            }
             lastLocation.setLongitude(GpsMockManager.getInstance().getLongitude());
             lastLocation.setLatitude(GpsMockManager.getInstance().getLatitude());
             lastLocation.setTime(System.currentTimeMillis());


### PR DESCRIPTION
Change-Id: I2a25dd2e3bb8189312b5c19f383eeaf92504a885

来源  开启GPS模拟，导致 app崩溃

当app调用
```java
 Location location = locationManager.getLastKnownLocation(LocationManager.GPS_PROVIDER);
```
location是有可能为null的。

在代理中没有加判断逻辑
https://github.com/didi/DoraemonKit/blob/a7895774ecb6a2002cd491447945281850c40ae1/Android/doraemonkit/src/main/java/com/didichuxing/doraemonkit/kit/gpsmock/LocationHooker.java#L94
https://github.com/didi/DoraemonKit/blob/a7895774ecb6a2002cd491447945281850c40ae1/Android/doraemonkit/src/main/java/com/didichuxing/doraemonkit/kit/gpsmock/LocationHooker.java#L95
```java
Location lastLocation = (Location) method.invoke(originService, args);
lastLocation.setLongitude(GpsMockManager.getInstance().getLongitude());
```
当lastLocation=null的时候，调用lastLocation.setLongitude()导致app崩溃。


既然是拦截修改，是否可以在获取为空的时候，干嘛不直接new一个对象返回呢？
加上Log和测试
```java
  if (lastLocation == null) {
                Log.e(TAG, "onInvoke:lastLocation ==null ");
                lastLocation = new Location("gps");
            }
```
验证为空
```bash
2019-09-27 17:14:59.862 31572-31657/com.app E/LocationHooker: onInvoke:lastLocation ==null 
2019-09-27 17:14:59.864 31572-31657/com.app E/LocationHooker: onInvoke:lastLocation ==null 

2019-09-27 17:24:40.295 32598-32598/com*** E/HomeActivity: onResume: 120.0
2019-09-27 17:24:40.295 32598-32598/com*** E/HomeActivity: onResume: 50.0
```
验证设置特定的值，在app获取成功。