### PR TITLE
fix 清理Crash日志,界面显示的日志大小未及时更新

### DIFF
--- a/Android/doraemonkit/src/main/java/com/didichuxing/doraemonkit/kit/crash/CrashCaptureMainFragment.java
+++ b/Android/doraemonkit/src/main/java/com/didichuxing/doraemonkit/kit/crash/CrashCaptureMainFragment.java
@@ -68,6 +68,7 @@ public class CrashCaptureMainFragment extends BaseFragment {
                     showContent(FileExplorerFragment.class, bundle);
                 } else if (data.desc == R.string.dk_crash_capture_clean_data) {
                     CrashCaptureManager.getInstance().clearCacheHistory();
+                    data.rightDesc = Formatter.formatFileSize(getContext(), FileUtil.getDirectorySize(CrashCaptureManager.getInstance().getCrashCacheDir()));
                     showToast(R.string.dk_crash_capture_clean_data);
                 }
             }


### PR DESCRIPTION

清理Crash日志,  界面显示的日志大小未及时刷新，再次进入界面才会刷新，会误以为没有删掉。

Change-Id: I339fa32590d18f8fcc5b8cb24578276109405b7f