### PR TITLE
清理Crash日志, 界面显示的日志大小未及时刷新

### DIFF
--- a/Android/doraemonkit/src/main/java/com/didichuxing/doraemonkit/kit/crash/CrashCaptureMainFragment.java
+++ b/Android/doraemonkit/src/main/java/com/didichuxing/doraemonkit/kit/crash/CrashCaptureMainFragment.java
@@ -68,6 +68,7 @@ public class CrashCaptureMainFragment extends BaseFragment {
                     showContent(FileExplorerFragment.class, bundle);
                 } else if (data.desc == R.string.dk_crash_capture_clean_data) {
                     CrashCaptureManager.getInstance().clearCacheHistory();
+                    data.rightDesc = Formatter.formatFileSize(getContext(), FileUtil.getDirectorySize(CrashCaptureManager.getInstance().getCrashCacheDir()));
                     showToast(R.string.dk_crash_capture_clean_data);
                 }
             }

--- a/Android/doraemonkit/src/main/java/com/didichuxing/doraemonkit/kit/crash/CrashCaptureMainFragment.java
+++ b/Android/doraemonkit/src/main/java/com/didichuxing/doraemonkit/kit/crash/CrashCaptureMainFragment.java
@@ -40,7 +40,7 @@ public class CrashCaptureMainFragment extends BaseFragment {
         });
         RecyclerView settingList = findViewById(R.id.setting_list);
         settingList.setLayoutManager(new LinearLayoutManager(getContext()));
-        SettingItemAdapter mSettingItemAdapter = new SettingItemAdapter(getContext());
+        final SettingItemAdapter mSettingItemAdapter = new SettingItemAdapter(getContext());
         mSettingItemAdapter.append(new SettingItem(R.string.dk_crash_capture_switch, CrashCaptureConfig.isCrashCaptureOpen(getContext())));
         mSettingItemAdapter.append(new SettingItem(R.string.dk_crash_capture_look, R.drawable.dk_more_icon));
         SettingItem item = new SettingItem(R.string.dk_crash_capture_clean_data);
@@ -69,6 +69,7 @@ public class CrashCaptureMainFragment extends BaseFragment {
                 } else if (data.desc == R.string.dk_crash_capture_clean_data) {
                     CrashCaptureManager.getInstance().clearCacheHistory();
                     data.rightDesc = Formatter.formatFileSize(getContext(), FileUtil.getDirectorySize(CrashCaptureManager.getInstance().getCrashCacheDir()));
+                    mSettingItemAdapter.notifyDataSetChanged();
                     showToast(R.string.dk_crash_capture_clean_data);
                 }
             }


### PR DESCRIPTION
清理Crash日志, 界面显示的日志大小未及时刷新，再次进入界面才会刷新，会误以为没有删掉。

已测试