### PR TITLE
[Fix] [addPluginWithTitle: icon:... ] when iconName is @""，icon will …

### DIFF
--- a/iOS/DoraemonKit/Src/Core/Category/UIImage+Doraemon.m
+++ b/iOS/DoraemonKit/Src/Core/Category/UIImage+Doraemon.m
@@ -11,7 +11,8 @@
 @implementation UIImage (Doraemon)
 
 + (UIImage *)doraemon_imageNamed:(NSString *)name{
-    if(name){
+    if(name &&
+       ![name isEqualToString:@""]){
         NSBundle *bundle = [NSBundle bundleForClass:NSClassFromString(@"DoraemonManager")];
         NSURL *url = [bundle URLForResource:@"DoraemonKit" withExtension:@"bundle"];
         if(!url) return nil;


### PR DESCRIPTION
…load wrong image because of [pathForResource:ofType:]
当addPluginWithTitle:... 方法 iconName 参数 传入 @""时，将加载错误的图片，
因为- (NSString *)pathForResource:(NSString *)name ofType:(NSString *)ext 方法，如果name为nil，则"If you specify nil, the method returns the first resource file it finds with the specified extension."