### PR TITLE
[iOS]: 增加查看、修改、清空 NSUserDefaults 数据功能

### DIFF
--- a/iOS/DoraemonKit/Src/Core/Manager/DoraemonManager.h
+++ b/iOS/DoraemonKit/Src/Core/Manager/DoraemonManager.h
@@ -43,6 +43,8 @@ typedef NS_ENUM(NSUInteger, DoraemonManagerPluginType) {
     DoraemonManagerPluginType_DoraemonCocoaLumberjackPlugin,
     // 数据库工具
     DoraemonManagerPluginType_DoraemonDatabasePlugin,
+    // NSUserDefaults工具
+    DoraemonManagerPluginType_DoraemonNSUserDefaultsPlugin,
     
     #pragma mark - 性能检测
     // 帧率监控

--- a/iOS/DoraemonKit/Src/Core/Manager/DoraemonManager.m
+++ b/iOS/DoraemonKit/Src/Core/Manager/DoraemonManager.m
@@ -224,6 +224,7 @@ typedef void (^DoraemonPerformanceBlock)(NSDictionary *);
     [self addPluginWithPluginType:DoraemonManagerPluginType_DoraemonDeleteLocalDataPlugin];
     
     [self addPluginWithPluginType:DoraemonManagerPluginType_DoraemonNSLogPlugin];
+    [self addPluginWithPluginType:DoraemonManagerPluginType_DoraemonNSUserDefaultsPlugin];
 #if DoraemonWithLogger
     [self addPluginWithPluginType:DoraemonManagerPluginType_DoraemonCocoaLumberjackPlugin];
 #endif
@@ -519,6 +520,14 @@ typedef void (^DoraemonPerformanceBlock)(NSDictionary *);
                                    @{kPluginName:@"DoraemonDatabasePlugin"},
                                    @{kAtModule:DoraemonLocalizedString(@"常用工具")}
                                    ],
+                           @(DoraemonManagerPluginType_DoraemonNSUserDefaultsPlugin) : @[
+                                   @{kTitle:@"NSUserDefaults"},
+                                   @{kDesc:@"NSUserDefaults"},
+                                   @{kIcon:@"doraemon_database"},
+                                   @{kPluginName:@"DoraemonNSUserDefaultsPlugin"},
+                                   @{kAtModule:DoraemonLocalizedString(@"常用工具")}
+                           ],
+                           
                            // 性能检测
                            @(DoraemonManagerPluginType_DoraemonFPSPlugin) : @[
                                    @{kTitle:DoraemonLocalizedString(@"帧率")},

--- a/iOS/DoraemonKit/Src/Core/Plugin/NSUserDefaults/DoraemonNSUserDefaultsPlugin.h
+++ b/iOS/DoraemonKit/Src/Core/Plugin/NSUserDefaults/DoraemonNSUserDefaultsPlugin.h
@@ -1,0 +1,17 @@
+//
+//  DoraemonNSUserDefaultsPlugin.h
+//  DoraemonKit
+//
+//  Created by 0xd-cc on 2019/11/26.
+//
+
+#import <Foundation/Foundation.h>
+#import "DoraemonPluginProtocol.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface DoraemonNSUserDefaultsPlugin : NSObject<DoraemonPluginProtocol>
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/iOS/DoraemonKit/Src/Core/Plugin/NSUserDefaults/DoraemonNSUserDefaultsPlugin.m
+++ b/iOS/DoraemonKit/Src/Core/Plugin/NSUserDefaults/DoraemonNSUserDefaultsPlugin.m
@@ -1,0 +1,18 @@
+//
+//  DoraemonNSUserDefaultsPlugin.m
+//  DoraemonKit
+//
+//  Created by 0xd-cc on 2019/11/26.
+//
+
+#import "DoraemonNSUserDefaultsPlugin.h"
+#import "DoraemonNSUserDefaultsViewController.h"
+#import "DoraemonHomeWindow.h"
+
+@implementation DoraemonNSUserDefaultsPlugin
+- (void)pluginDidLoad{
+    DoraemonNSUserDefaultsViewController *vc = [[DoraemonNSUserDefaultsViewController alloc] init];
+    [DoraemonHomeWindow openPlugin:vc];
+}
+
+@end

--- a/iOS/DoraemonKit/Src/Core/Plugin/NSUserDefaults/Model/DoraemonNSUserDefaultsModel.h
+++ b/iOS/DoraemonKit/Src/Core/Plugin/NSUserDefaults/Model/DoraemonNSUserDefaultsModel.h
@@ -1,0 +1,17 @@
+//
+//  DoraemonNSUserDefaultsModel.h
+//  DoraemonKit
+//
+//  Created by 0xd-cc on 2019/11/26.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface DoraemonNSUserDefaultsModel : NSObject
+@property (nonatomic, copy) NSString *key;
+@property (nonatomic, strong) id value;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/iOS/DoraemonKit/Src/Core/Plugin/NSUserDefaults/Model/DoraemonNSUserDefaultsModel.m
+++ b/iOS/DoraemonKit/Src/Core/Plugin/NSUserDefaults/Model/DoraemonNSUserDefaultsModel.m
@@ -1,0 +1,12 @@
+//
+//  DoraemonNSUserDefaultsModel.m
+//  DoraemonKit
+//
+//  Created by 0xd-cc on 2019/11/26.
+//
+
+#import "DoraemonNSUserDefaultsModel.h"
+
+@implementation DoraemonNSUserDefaultsModel
+
+@end

--- a/iOS/DoraemonKit/Src/Core/Plugin/NSUserDefaults/ViewControllers/DoraemonNSUserDefaultsEditViewController.h
+++ b/iOS/DoraemonKit/Src/Core/Plugin/NSUserDefaults/ViewControllers/DoraemonNSUserDefaultsEditViewController.h
@@ -1,0 +1,19 @@
+//
+//  DoraemonNSUserDefaultsEditViewController.h
+//  DoraemonKit
+//
+//  Created by 0xd-cc on 2019/11/26.
+//
+
+#import <DoraemonKit/DoraemonKit.h>
+@class DoraemonNSUserDefaultsModel;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface DoraemonNSUserDefaultsEditViewController : DoraemonBaseViewController
+@property (nonatomic, strong) DoraemonNSUserDefaultsModel *model;
+
+- (instancetype)initWithModel: (DoraemonNSUserDefaultsModel *)model;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/iOS/DoraemonKit/Src/Core/Plugin/NSUserDefaults/ViewControllers/DoraemonNSUserDefaultsEditViewController.m
+++ b/iOS/DoraemonKit/Src/Core/Plugin/NSUserDefaults/ViewControllers/DoraemonNSUserDefaultsEditViewController.m
@@ -1,0 +1,35 @@
+//
+//  DoraemonNSUserDefaultsEditViewController.m
+//  DoraemonKit
+//
+//  Created by 0xd-cc on 2019/11/26.
+//
+
+#import "DoraemonNSUserDefaultsEditViewController.h"
+#import "DoraemonDefine.h"
+#import "DoraemonNSUserDefaultsModel.h"
+
+@interface DoraemonNSUserDefaultsEditViewController ()
+@property (nonatomic, strong) UITextView *textView;
+@end
+
+@implementation DoraemonNSUserDefaultsEditViewController
+
+- (instancetype)initWithModel: (DoraemonNSUserDefaultsModel *)model
+{
+    self = [super init];
+    if (self) {
+        self.model = model;
+    }
+    return self;
+}
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    self.textView = [[UITextView alloc] initWithFrame:CGRectMake(0, IPHONE_NAVIGATIONBAR_HEIGHT, self.view.doraemon_width, self.view.doraemon_height-IPHONE_NAVIGATIONBAR_HEIGHT)];
+    [self.view addSubview:self.textView];
+    self.title = self.model.key;
+    self.textView.text = [self.model.value description];
+}
+
+@end

--- a/iOS/DoraemonKit/Src/Core/Plugin/NSUserDefaults/ViewControllers/DoraemonNSUserDefaultsEditViewController.m
+++ b/iOS/DoraemonKit/Src/Core/Plugin/NSUserDefaults/ViewControllers/DoraemonNSUserDefaultsEditViewController.m
@@ -30,6 +30,15 @@
     [self.view addSubview:self.textView];
     self.title = self.model.key;
     self.textView.text = [self.model.value description];
+    
+    UIBarButtonItem *item = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(submit)];
+    self.navigationItem.rightBarButtonItems = @[item];
+    self.title = @"Edit";
+}
+
+- (void)submit {
+    [[NSUserDefaults standardUserDefaults] setObject:self.textView.text forKey:_model.key];
+    [self.navigationController popViewControllerAnimated:true];
 }
 
 @end

--- a/iOS/DoraemonKit/Src/Core/Plugin/NSUserDefaults/ViewControllers/DoraemonNSUserDefaultsViewController.h
+++ b/iOS/DoraemonKit/Src/Core/Plugin/NSUserDefaults/ViewControllers/DoraemonNSUserDefaultsViewController.h
@@ -1,0 +1,17 @@
+//
+//  DoraemonNSUserDefaultsViewController.h
+//  DoraemonKit
+//
+//  Created by 0xd-cc on 2019/11/26.
+//
+
+#import <UIKit/UIKit.h>
+#import "DoraemonBaseViewController.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface DoraemonNSUserDefaultsViewController : DoraemonBaseViewController
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/iOS/DoraemonKit/Src/Core/Plugin/NSUserDefaults/ViewControllers/DoraemonNSUserDefaultsViewController.m
+++ b/iOS/DoraemonKit/Src/Core/Plugin/NSUserDefaults/ViewControllers/DoraemonNSUserDefaultsViewController.m
@@ -7,7 +7,6 @@
 
 #import "DoraemonNSUserDefaultsViewController.h"
 #import "DoraemonDefine.h"
-#import "DoraemonNSUserDefaultsCell.h"
 #import "DoraemonNSUserDefaultsModel.h"
 #import "DoraemonNSUserDefaultsEditViewController.h"
 
@@ -21,7 +20,7 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
     
-    UIBarButtonItem *item = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemTrash target:nil action:nil];
+    UIBarButtonItem *item = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemTrash target:self action:@selector(clearUserDefaults)];
     self.navigationItem.rightBarButtonItems = @[item];
     
     self.tableView = [[UITableView alloc] initWithFrame:CGRectMake(0, IPHONE_NAVIGATIONBAR_HEIGHT, self.view.doraemon_width, self.view.doraemon_height-IPHONE_NAVIGATIONBAR_HEIGHT) style:UITableViewStylePlain];
@@ -29,7 +28,14 @@
     self.tableView.delegate = self;
     self.tableView.dataSource = self;
     [self.view addSubview:self.tableView];
-    
+}
+
+- (void)viewWillAppear:(BOOL)animated {
+    [super viewWillAppear:animated];
+    [self reload];
+}
+
+- (void)reload {
     NSDictionary<NSString *, id> *dic = [[NSUserDefaults standardUserDefaults] dictionaryRepresentation];
     self.modelList = [NSMutableArray array];
     [dic enumerateKeysAndObjectsUsingBlock:^(NSString * _Nonnull key, id  _Nonnull obj, BOOL * _Nonnull stop) {
@@ -41,19 +47,15 @@
     [self.tableView reloadData];
 }
 
-- (NSDictionary<NSString *, id> *)dictionaryRepresentation {
-    return [[NSUserDefaults standardUserDefaults] dictionaryRepresentation];
-}
-
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
     return self.modelList.count;
 }
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
     static NSString *identifer = @"DoraemonNSUserDefaultsViewControllerCell";
-    DoraemonNSUserDefaultsCell *cell = [tableView dequeueReusableCellWithIdentifier:identifer];
+    UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:identifer];
     if (!cell) {
-        cell = [[DoraemonNSUserDefaultsCell alloc] initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:identifer];
+        cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:identifer];
     }
     DoraemonNSUserDefaultsModel *model = self.modelList[indexPath.row];
     cell.textLabel.text = model.key;
@@ -66,6 +68,16 @@
     DoraemonNSUserDefaultsModel *model = self.modelList[indexPath.row];
     DoraemonNSUserDefaultsEditViewController *vc = [[DoraemonNSUserDefaultsEditViewController alloc] initWithModel:model];
     [self.navigationController pushViewController:vc animated:true];
+}
+
+- (void)clearUserDefaults {
+    [DoraemonAlertUtil handleAlertActionWithVC:self text:@"clear all data?" okBlock:^{
+        NSString *bundleIdentifier = NSBundle.mainBundle.bundleIdentifier;
+        [[NSUserDefaults standardUserDefaults] removePersistentDomainForName:bundleIdentifier];
+        [self reload];
+    } cancleBlock:^{
+    
+    }];
 }
 
 @end

--- a/iOS/DoraemonKit/Src/Core/Plugin/NSUserDefaults/ViewControllers/DoraemonNSUserDefaultsViewController.m
+++ b/iOS/DoraemonKit/Src/Core/Plugin/NSUserDefaults/ViewControllers/DoraemonNSUserDefaultsViewController.m
@@ -1,0 +1,71 @@
+//
+//  DoraemonNSUserDefaultsViewController.m
+//  DoraemonKit
+//
+//  Created by 0xd-cc on 2019/11/26.
+//
+
+#import "DoraemonNSUserDefaultsViewController.h"
+#import "DoraemonDefine.h"
+#import "DoraemonNSUserDefaultsCell.h"
+#import "DoraemonNSUserDefaultsModel.h"
+#import "DoraemonNSUserDefaultsEditViewController.h"
+
+@interface DoraemonNSUserDefaultsViewController ()<UITableViewDelegate,UITableViewDataSource>
+@property (nonatomic, strong) UITableView *tableView;
+@property (nonatomic, strong) NSMutableArray<DoraemonNSUserDefaultsModel *> *modelList;
+@end
+
+@implementation DoraemonNSUserDefaultsViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    
+    UIBarButtonItem *item = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemTrash target:nil action:nil];
+    self.navigationItem.rightBarButtonItems = @[item];
+    
+    self.tableView = [[UITableView alloc] initWithFrame:CGRectMake(0, IPHONE_NAVIGATIONBAR_HEIGHT, self.view.doraemon_width, self.view.doraemon_height-IPHONE_NAVIGATIONBAR_HEIGHT) style:UITableViewStylePlain];
+        self.tableView.backgroundColor = [UIColor whiteColor];
+    self.tableView.delegate = self;
+    self.tableView.dataSource = self;
+    [self.view addSubview:self.tableView];
+    
+    NSDictionary<NSString *, id> *dic = [[NSUserDefaults standardUserDefaults] dictionaryRepresentation];
+    self.modelList = [NSMutableArray array];
+    [dic enumerateKeysAndObjectsUsingBlock:^(NSString * _Nonnull key, id  _Nonnull obj, BOOL * _Nonnull stop) {
+        DoraemonNSUserDefaultsModel *model = [[DoraemonNSUserDefaultsModel alloc] init];
+        model.key = key;
+        model.value = obj;
+        [self.modelList addObject:model];
+    }];
+    [self.tableView reloadData];
+}
+
+- (NSDictionary<NSString *, id> *)dictionaryRepresentation {
+    return [[NSUserDefaults standardUserDefaults] dictionaryRepresentation];
+}
+
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
+    return self.modelList.count;
+}
+
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
+    static NSString *identifer = @"DoraemonNSUserDefaultsViewControllerCell";
+    DoraemonNSUserDefaultsCell *cell = [tableView dequeueReusableCellWithIdentifier:identifer];
+    if (!cell) {
+        cell = [[DoraemonNSUserDefaultsCell alloc] initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:identifer];
+    }
+    DoraemonNSUserDefaultsModel *model = self.modelList[indexPath.row];
+    cell.textLabel.text = model.key;
+    cell.detailTextLabel.text = [model.value description];
+    cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
+    return cell;
+}
+
+- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
+    DoraemonNSUserDefaultsModel *model = self.modelList[indexPath.row];
+    DoraemonNSUserDefaultsEditViewController *vc = [[DoraemonNSUserDefaultsEditViewController alloc] initWithModel:model];
+    [self.navigationController pushViewController:vc animated:true];
+}
+
+@end


### PR DESCRIPTION
开发、调试、自测、经常遇到需要查看NSUserDefaults数据的功能，增加一个工具用来查看、修改、清空 NSUserDefaults

优点： 
一眼看到NSUserDefaults 已存储状态（如是否登录）
可以修改NSUserDefaults已存储数据：不用每次测试其他状态时，通过代码修改NSUserDefaults
一键清空所有数据：如重置登录状态、重置所有标志位，方便QA测试，不用每次都卸载App来清空NSUserDefaults数据