### PR TITLE
Update DoraemonManager.m

### DIFF
--- a/iOS/DoraemonKit/Src/Core/Manager/DoraemonManager.m
+++ b/iOS/DoraemonKit/Src/Core/Manager/DoraemonManager.m
@@ -392,6 +392,9 @@ typedef void (^DoraemonPerformanceBlock)(NSDictionary *);
 }
 
 - (BOOL)isShowDoraemon{
+    if (!_entryWindow) {
+        return NO;
+    }
     return !_entryWindow.hidden;
 }
 


### PR DESCRIPTION
当没有调用installWithPid:方法之前调用[[DoraemonManager shareInstance] isShowDoraemon]时，因为
```
- (BOOL)isShowDoraemon{
    return !_entryView.hidden;
}
```
因`_entryView`还不存在，所以会直接返回YES，导致判断出现bug；