### PR TITLE
[iOS] Add two methods on GMPMocker for iOS 13 

### DIFF
--- a/iOS/DoraemonKit/Src/GPS/Function/DoraemonGPSMocker.m
+++ b/iOS/DoraemonKit/Src/GPS/Function/DoraemonGPSMocker.m
@@ -172,6 +172,22 @@
     }];
 }
 
+- (void)locationManager:(CLLocationManager *)manager didRangeBeacons:(NSArray<CLBeacon *> *)beacons satisfyingConstraint:(CLBeaconIdentityConstraint *)beaconConstraint API_AVAILABLE(ios(13.0)) {
+    [self enumDelegate:manager block:^(id<CLLocationManagerDelegate> delegate) {
+        if ([delegate respondsToSelector:@selector(locationManager:didRangeBeacons:satisfyingConstraint:)]) {
+            [delegate locationManager:manager didRangeBeacons:beacons satisfyingConstraint:beaconConstraint];
+        }
+    }];
+}
+
+- (void)locationManager:(CLLocationManager *)manager didFailRangingBeaconsForConstraint:(CLBeaconIdentityConstraint *)beaconConstraint error:(NSError *)error API_AVAILABLE(ios(13.0)) {
+    [self enumDelegate:manager block:^(id<CLLocationManagerDelegate> delegate) {
+        if ([delegate respondsToSelector:@selector(locationManager:didFailRangingBeaconsForConstraint:error:)]) {
+            [delegate locationManager:manager didFailRangingBeaconsForConstraint:beaconConstraint error:error];
+        }
+    }];
+}
+
 - (void)locationManager:(CLLocationManager *)manager
          didEnterRegion:(CLRegion *)region{
     [self enumDelegate:manager block:^(id<CLLocationManagerDelegate> delegate) {


### PR DESCRIPTION
DoraemonKit crash when start location under iOS 13.0.

The reason is CLLocationManager have two new delegate method need implement in DoraemonGPSMocker:

`- (void)locationManager:(CLLocationManager *)manager didRangeBeacons:(NSArray<CLBeacon *> *)beacons satisfyingConstraint:(CLBeaconIdentityConstraint *)beaconConstraint API_AVAILABLE(ios(13.0))`

`- (void)locationManager:(CLLocationManager *)manager didFailRangingBeaconsForConstraint:(CLBeaconIdentityConstraint *)beaconConstraint error:(NSError *)error API_AVAILABLE(ios(13.0))`

