### PR TITLE
Performance

### DIFF
--- a/iOS/Swift/DoKitSwift/Src/Plugins/Performance/Performance.swift
+++ b/iOS/Swift/DoKitSwift/Src/Plugins/Performance/Performance.swift
@@ -1,0 +1,61 @@
+//
+//  Performance.swift
+//  DoraemonKit-Swift
+//
+//  Created by objc on 2020/6/9.
+//
+
+import Foundation
+import Darwin.Mach
+
+private let TASK_BASIC_INFO_COUNT = mach_msg_type_number_t(MemoryLayout<task_basic_info_data_t>.size / MemoryLayout<UInt32>.size)
+private let TASK_VM_INFO_COUNT = mach_msg_type_number_t(MemoryLayout<task_vm_info_data_t>.size / MemoryLayout<UInt32>.size)
+
+struct Performance {
+    static var cpuUsage: Double {
+        var arr: thread_act_array_t?
+        var threadCount: mach_msg_type_number_t = 0
+
+        guard task_threads(mach_task_self_, &arr, &threadCount) == KERN_SUCCESS else { return -1 }
+        guard let threads = arr else { return -1 }
+
+        defer {
+            let size = MemoryLayout<thread_t>.size * Int(threadCount)
+            vm_deallocate(mach_task_self_, vm_address_t(bitPattern: threads), vm_size_t(size))
+        }
+
+        var total = 0.0
+
+        for i in 0..<Int(threadCount) {
+            var info = thread_basic_info()
+            var infoCount = TASK_BASIC_INFO_COUNT
+
+            let result = withUnsafeMutablePointer(to: &info) {
+                $0.withMemoryRebound(to: integer_t.self, capacity: 1) {
+                    thread_info(threads[i], thread_flavor_t(THREAD_BASIC_INFO), $0, &infoCount)
+                }
+            }
+            guard result == KERN_SUCCESS else { return -1 }
+
+            if info.flags & TH_FLAGS_IDLE == 0 {
+                total += Double(info.cpu_usage) / Double(TH_USAGE_SCALE) * 100.0
+            }
+        }
+
+        return total
+    }
+
+    static var memoryUsage: String {
+        var info = task_vm_info_data_t()
+        var infoCount = TASK_VM_INFO_COUNT
+
+        let result = withUnsafeMutablePointer(to: &info) {
+            $0.withMemoryRebound(to: integer_t.self, capacity: 1) {
+                task_info(mach_task_self_, thread_flavor_t(TASK_VM_INFO), $0, &infoCount)
+            }
+        }
+        guard result == KERN_SUCCESS else { return "" }
+
+        return ByteCountFormatter.string(fromByteCount: Int64(info.internal), countStyle: .memory)
+    }
+}

--- a/iOS/Swift/DoKitSwiftDemo/DoKitSwiftDemo.xcodeproj/project.pbxproj
+++ b/iOS/Swift/DoKitSwiftDemo/DoKitSwiftDemo.xcodeproj/project.pbxproj
@@ -40,7 +40,7 @@
 		0AE102A524693DAB006CA490 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0AE102A324693DAB006CA490 /* Main.storyboard */; };
 		0AE102A724693DAD006CA490 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0AE102A624693DAD006CA490 /* Assets.xcassets */; };
 		0AE102AA24693DAD006CA490 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0AE102A824693DAD006CA490 /* LaunchScreen.storyboard */; };
-		7606F3089C89D413F88E415C /* libPods-DoKitSwiftDemo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 57491D3C6A0E4E5521217F1B /* libPods-DoKitSwiftDemo.a */; };
+		551C20B2E55A31BF2E07C0FC /* libPods-DoKitSwiftDemo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 57491D3C6A0E4E5521217F1B /* libPods-DoKitSwiftDemo.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -94,7 +94,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				7606F3089C89D413F88E415C /* libPods-DoKitSwiftDemo.a in Frameworks */,
+				551C20B2E55A31BF2E07C0FC /* libPods-DoKitSwiftDemo.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -310,7 +310,6 @@
 				0AE1029624693DAB006CA490 /* Sources */,
 				0AE1029724693DAB006CA490 /* Frameworks */,
 				0AE1029824693DAB006CA490 /* Resources */,
-				69356E1B92816D4FCAB695A6 /* [CP] Embed Pods Frameworks */,
 				C95DB2F42480C61600BC30DB /* Build Info */,
 				963800CFF4ADF64CDE973315 /* [CP] Copy Pods Resources */,
 			);


### PR DESCRIPTION
## Added
- Calculate CPU usage and memory usage.

## Resolved
- Suppress pod warning
````
[!] `<PBXNativeTarget name=`DoKitSwiftDemo` UUID=`0AE1029924693DAB006CA490`>` attempted to initialize an object with an unknown UUID. `69356E1B92816D4FCAB695A6` for attribute: `build_phases`. This can be the result of a merge and the unknown UUID is being discarded.
````
