### PR TITLE
Optimize fetch image data

### DIFF
--- a/iOS/DoraemonKit/Src/Core/Plugin/Performance/LargeImageDetection/Function/UIImageView+DoraemonSDImage.m
+++ b/iOS/DoraemonKit/Src/Core/Plugin/Performance/LargeImageDetection/Function/UIImageView+DoraemonSDImage.m
@@ -14,55 +14,50 @@
 
 @implementation UIImageView (DoraemonSDImage)
 
-+ (void)load{
++ (void)load {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wundeclared-selector"
     
-    Method originAddObserverMethod = class_getInstanceMethod(self, @selector(sd_setImageWithURL:placeholderImage:options:context:progress:completed:));
-    if (originAddObserverMethod) {
+    BOOL respondToSelector = [UIImageView instancesRespondToSelector:@selector(sd_internalSetImageWithURL:placeholderImage:options:context:setImageBlock:progress:completed:)];
+    if (respondToSelector) {
         // 兼容SDWebImage 最新版本 5.0.6
-        [self doraemon_swizzleInstanceMethodWithOriginSel:@selector(sd_setImageWithURL:placeholderImage:options:context:progress:completed:)
-                                              swizzledSel:@selector(doraemon_sd_setImageWithURL:placeholderImage:options:context:progress:completed:)];
-    }else{
+        [self doraemon_swizzleInstanceMethodWithOriginSel:@selector(sd_internalSetImageWithURL:placeholderImage:options:context:setImageBlock:progress:completed:)
+                                              swizzledSel:@selector(doraemon_sd_internalSetImageWithURL:placeholderImage:options:context:setImageBlock:progress:completed:)];
+    } else {
         // 兼容SDWebImage 我们使用的版本 3.7.6
         [self doraemon_swizzleInstanceMethodWithOriginSel:@selector(sd_setImageWithURL:placeholderImage:options:progress:completed:) swizzledSel:@selector(doraemon_sd_setImageWithURL:placeholderImage:options:progress:completed:)];
     }
-    //估计以后还会兼容其他版本啊。哭。
-    #pragma clang diagnostic pop
+#pragma clang diagnostic pop
 }
 
-- (void)doraemon_sd_setImageWithURL:(nullable NSURL *)url
-          placeholderImage:(nullable UIImage *)placeholder
-                   options:(NSUInteger)options
-                   context:(id)context
-                  progress:(id)progressBlock
-                          completed:(void(^)(UIImage * _Nullable image, NSError * _Nullable error, NSInteger cacheType, NSURL * _Nullable imageURL))completedBlock{
+- (void)doraemon_sd_internalSetImageWithURL:(nullable NSURL *)url
+                           placeholderImage:(nullable UIImage *)placeholder
+                                    options:(NSUInteger)options
+                                    context:(id)context
+                              setImageBlock:(id)setImageBlock
+                                   progress:(id)progressBlock
+                                  completed:(void(^)(UIImage * _Nullable image, NSData * _Nullable data, NSError * _Nullable error, NSInteger cacheType, BOOL finished, NSURL * _Nullable imageURL))completedBlock {
     
     __weak typeof(self) weafSelf = self;
     if ([DoraemonLargeImageDetectionManager shareInstance].detecting) {
-        id replaceCompletedBlock = ^(UIImage * _Nullable image, NSError * _Nullable error, NSInteger cacheType, NSURL * _Nullable imageURL){
-            NSData *data = UIImageJPEGRepresentation(image, 1.0);
-            if (!data && data.length <= 0) {
-                data = UIImagePNGRepresentation(image);
-            }
+        id replaceCompletedBlock = ^(UIImage * _Nullable image, NSData * _Nullable data, NSError * _Nullable error, NSInteger cacheType,BOOL finished, NSURL * _Nullable imageURL) {
             if (data.length > [DoraemonLargeImageDetectionManager shareInstance].minimumDetectionSize) {
                 NSString *drawText = [NSString stringWithFormat:@"url : %@ \n size : %fKB",[url absoluteString],data.length/1024.];
                 weafSelf.image = [self drawText:drawText inImage:weafSelf.image];
             }
             if (completedBlock) {
-                completedBlock(weafSelf.image, error, cacheType,imageURL);
+                completedBlock(weafSelf.image, data, error, cacheType, finished, imageURL);
             }
-            
         };
-        [self doraemon_sd_setImageWithURL:url placeholderImage:placeholder options:options context:context progress:progressBlock completed:replaceCompletedBlock];
-    }else{
-        [self doraemon_sd_setImageWithURL:url placeholderImage:placeholder options:options context:context progress:progressBlock completed:completedBlock];
+        [self doraemon_sd_internalSetImageWithURL:url placeholderImage:placeholder options:options context:context setImageBlock:setImageBlock progress:progressBlock completed:replaceCompletedBlock];
+    } else {
+        [self doraemon_sd_internalSetImageWithURL:url placeholderImage:placeholder options:options context:context setImageBlock:setImageBlock progress:progressBlock completed:completedBlock];
     }
 }
 
 - (void)doraemon_sd_setImageWithURL:(NSURL *)url placeholderImage:(UIImage *)placeholder options:(NSUInteger)options progress:(id)progressBlock completed:(void(^)(UIImage *image, NSError *error, NSInteger cacheType, NSURL *imageURL))completedBlock{
     __weak typeof(self) weafSelf = self;
-    if ([DoraemonLargeImageDetectionManager shareInstance].detecting){
+    if ([DoraemonLargeImageDetectionManager shareInstance].detecting) {
         id replaceCompletedBlock = ^(UIImage *image, NSError *error, NSInteger cacheType, NSURL *imageURL) {
             NSData *data = UIImageJPEGRepresentation(image, 1.0);
             if (!data && data.length <= 0) {
@@ -77,16 +72,16 @@
             }
         };
         [self doraemon_sd_setImageWithURL:url placeholderImage:placeholder options:options progress:progressBlock completed:replaceCompletedBlock];
-    }else{
+    } else {
         [self doraemon_sd_setImageWithURL:url placeholderImage:placeholder options:options progress:progressBlock completed:completedBlock];
     }
 }
 
-- (UIImage *)drawText:(NSString *)text inImage:(UIImage *)image{
+- (UIImage *)drawText:(NSString *)text inImage:(UIImage *)image {
     UIFont *font = [UIFont boldSystemFontOfSize:12 * (image.size.height / 230)];
     UIGraphicsBeginImageContextWithOptions(image.size, NO, [UIScreen mainScreen].scale);
-    [image drawInRect:CGRectMake(0, 0, image.size.width, image.size.height)];
     CGRect rect = CGRectMake(0, 0, image.size.width, image.size.height);
+    [image drawInRect:rect];
     [text drawInRect:CGRectIntegral(rect) withAttributes:@{
                                                            NSFontAttributeName : font,
                                                            NSForegroundColorAttributeName : [UIColor redColor]


### PR DESCRIPTION
问题①：在SD底层的`sd_internalSetImageWithURL`接口中可以获取到图片的元数据大小，没有必要使用非常耗时的`UIImageJPEGRepresentation()`来获取。

问题②：现在项目大部分人使用的是`SDAnimatedImageView`并且对应实现了`sd_setImageWithURL`方法, 如果 hook UIImageView的`sd_setImageWithURL`方法，并不能监听到`SDAnimatedImageView`图片的下载大小，而`sd_internalSetImageWithURL`可以兼容`UIImageView`和`SDAnimatedImageView`。