### PR TITLE
第三方库信息列表支持实时搜索、排序

### DIFF
--- a/Android/java/buildSrc/src/main/kotlin/com/didichuxing/doraemonkit/plugin/DoKitPlugin.kt
+++ b/Android/java/buildSrc/src/main/kotlin/com/didichuxing/doraemonkit/plugin/DoKitPlugin.kt
@@ -14,7 +14,6 @@ import com.didiglobal.booster.gradle.getProperty
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.result.ResolvedArtifactResult
-import org.gradle.api.invocation.Gradle
 
 /**
  * ================================================
@@ -149,7 +148,8 @@ class DoKitPlugin : Plugin<Project> {
                                         val thirdLibInfo =
                                             ThirdLibInfo(
                                                 fileName,
-                                                DoKitPluginUtil.fileSize(artifactResult.file, 2)
+                                                    artifactResult.file.length(),
+                                                artifactResult.variant.displayName
                                             )
                                         DoKitExtUtil.THIRD_LIB_INFOS.add(thirdLibInfo)
                                     }

--- a/Android/java/buildSrc/src/main/kotlin/com/didichuxing/doraemonkit/plugin/ThirdLibInfo.kt
+++ b/Android/java/buildSrc/src/main/kotlin/com/didichuxing/doraemonkit/plugin/ThirdLibInfo.kt
@@ -9,4 +9,4 @@ package com.didichuxing.doraemonkit.plugin
  * 修订历史：
  * ================================================
  */
-data class ThirdLibInfo(val name: String, val fileSize: String? = "0kb")
+data class ThirdLibInfo(val name: String, val fileSize: Long, val variant : String)

--- a/Android/java/buildSrc/src/main/kotlin/com/didichuxing/doraemonkit/plugin/classtransformer/CommTransformer.kt
+++ b/Android/java/buildSrc/src/main/kotlin/com/didichuxing/doraemonkit/plugin/classtransformer/CommTransformer.kt
@@ -407,8 +407,8 @@ class CommTransformer : ClassTransformer {
 
             for (thirdLibInfo in DoKitExtUtil.THIRD_LIB_INFOS) {
                 add(VarInsnNode(ALOAD, 0))
-                add(LdcInsnNode(thirdLibInfo.name))
-                add(LdcInsnNode(thirdLibInfo.fileSize))
+                add(LdcInsnNode(thirdLibInfo.variant))
+                add(LdcInsnNode(thirdLibInfo.fileSize.toString()))
 
                 add(
                     MethodInsnNode(

--- a/Android/java/doraemonkit/src/main/java/com/didichuxing/doraemonkit/kit/sysinfo/ThirdLibInfoItemAdapter.java
+++ b/Android/java/doraemonkit/src/main/java/com/didichuxing/doraemonkit/kit/sysinfo/ThirdLibInfoItemAdapter.java
@@ -1,6 +1,7 @@
 package com.didichuxing.doraemonkit.kit.sysinfo;
 
 import android.content.Context;
+import android.text.format.Formatter;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -68,7 +69,7 @@ public class ThirdLibInfoItemAdapter extends AbsRecyclerAdapter<AbsViewBinder<Sy
         @Override
         public void bind(final SysInfoItem sysInfoItem) {
             mTvName.setText(sysInfoItem.name);
-            mTvSize.setText(sysInfoItem.value);
+            mTvSize.setText(Formatter.formatFileSize(itemView.getContext(), Long.parseLong(sysInfoItem.value)));
 
         }
     }

--- a/Android/java/doraemonkit/src/main/res/layout/dk_fragment_third_lib_info.xml
+++ b/Android/java/doraemonkit/src/main/res/layout/dk_fragment_third_lib_info.xml
@@ -21,24 +21,36 @@
         android:layout_marginLeft="16dp"
         android:layout_marginRight="16dp">
 
-        <TextView
-            android:id="@+id/tv_search"
-            android:layout_width="wrap_content"
-            android:layout_height="36dp"
+        <RadioGroup
             android:layout_alignParentRight="true"
-            android:layout_centerVertical="true"
             android:layout_marginLeft="8dp"
-            android:gravity="center"
-            android:text="@string/dk_mock_search"
-            android:textColor="@color/dk_color_337CC4"
-            android:textSize="14sp" />
+            android:layout_centerVertical="true"
+            android:id="@+id/sort_option"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <RadioButton
+                android:checked="true"
+                android:id="@+id/sort_name"
+                style="@style/DK.RadioButton.Left"
+                android:layout_weight="1"
+                android:text="@string/dk_third_sort_name" />
+
+            <RadioButton
+                android:id="@+id/sort_size"
+                style="@style/DK.RadioButton.Right"
+                android:layout_weight="1"
+                android:text="@string/dk_third_sort_size" />
+
+        </RadioGroup>
 
         <androidx.cardview.widget.CardView
             android:id="@+id/cardview"
             android:layout_width="match_parent"
             android:layout_height="36dp"
             android:layout_margin="5dp"
-            android:layout_toLeftOf="@id/tv_search"
+            android:layout_toLeftOf="@id/sort_option"
             app:cardBackgroundColor="@color/dk_color_FFFFFF"
             app:cardCornerRadius="4dp"
             app:cardElevation="3dp"
@@ -48,6 +60,7 @@
             app:contentPaddingTop="5dp">
 
             <EditText
+                android:singleLine="true"
                 android:id="@+id/edittext"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"

--- a/Android/java/doraemonkit/src/main/res/layout/dk_fragment_weak_network.xml
+++ b/Android/java/doraemonkit/src/main/res/layout/dk_fragment_weak_network.xml
@@ -35,7 +35,7 @@
         android:paddingRight="@dimen/dk_dp_15"
         android:visibility="gone"
         tools:visibility="visible">
-        <!--        redioGroup-->
+        <!--        radioGroup-->
         <RadioGroup
             android:id="@+id/weak_network_option"
             android:layout_width="match_parent"

--- a/Android/java/doraemonkit/src/main/res/values-en-rUS/strings.xml
+++ b/Android/java/doraemonkit/src/main/res/values-en-rUS/strings.xml
@@ -133,6 +133,9 @@
     <string name="dk_item_block_goto_list">View Block History</string>
     <string name="dk_item_block_mock">Mock Block</string>
 
+    <string name="dk_third_sort_name">By Name</string>
+    <string name="dk_third_sort_size">By Size</string>
+
     <string name="dk_block_class_has_blocked">blocked %s ms</string>
     <string name="dk_block_notification_message">Click for more details</string>
 

--- a/Android/java/doraemonkit/src/main/res/values-zh-rCN/strings.xml
+++ b/Android/java/doraemonkit/src/main/res/values-zh-rCN/strings.xml
@@ -135,6 +135,9 @@
     <string name="dk_item_block_goto_list">查看卡顿记录</string>
     <string name="dk_item_block_mock">模拟卡顿</string>
 
+    <string name="dk_third_sort_name">按名称</string>
+    <string name="dk_third_sort_size">按大小</string>
+
     <string name="dk_block_class_has_blocked">blocked %s ms</string>
     <string name="dk_block_notification_message">Click for more details</string>
 

--- a/Android/java/doraemonkit/src/main/res/values-zh-rTW/strings.xml
+++ b/Android/java/doraemonkit/src/main/res/values-zh-rTW/strings.xml
@@ -133,6 +133,9 @@
     <string name="dk_item_block_goto_list">查看 ANR 紀錄</string>
     <string name="dk_item_block_mock">模擬 ANR</string>
 
+    <string name="dk_third_sort_name">按名稱</string>
+    <string name="dk_third_sort_size">按大小</string>
+
     <string name="dk_block_class_has_blocked">blocked %s ms</string>
     <string name="dk_block_notification_message">Click for more details</string>
 

--- a/Android/java/doraemonkit/src/main/res/values/strings.xml
+++ b/Android/java/doraemonkit/src/main/res/values/strings.xml
@@ -149,6 +149,9 @@
     <string name="dk_block_class_has_blocked">blocked %s ms</string>
     <string name="dk_block_notification_message">Click for more details</string>
 
+    <string name="dk_third_sort_name">按名称</string>
+    <string name="dk_third_sort_size">按大小</string>
+
     <string name="dk_crash_capture_tips">DoraemonKit正在为您记录Crash</string>
     <string name="dk_crash_capture_no_record">暂无crash记录</string>
     <string name="dk_crash_capture_switch">Crash日志收集开关</string>


### PR DESCRIPTION
去掉了原来的搜索按钮，输入文本会即时搜索并且不区分大小写
增加按名称和按大小排序，大小排序能更快的找出占用最大的库

<img src="https://user-images.githubusercontent.com/17588779/103397686-5f2ce780-4b74-11eb-9ed9-811e8b8e0631.gif" width="300"/>