### PR TITLE
fix getCpuDataForO(), avoid ANSI escape codes.

### DIFF
--- a/Android/java/doraemonkit/src/main/java/com/didichuxing/doraemonkit/kit/performance/PerformanceDataManager.java
+++ b/Android/java/doraemonkit/src/main/java/com/didichuxing/doraemonkit/kit/performance/PerformanceDataManager.java
@@ -129,7 +129,7 @@ public class PerformanceDataManager {
                     cpuIndex = tempIndex;
                     continue;
                 }
-                if (line.startsWith(String.valueOf(Process.myPid()))) {
+                if (line.contains(String.valueOf(Process.myPid()))) {
                     if (cpuIndex == -1) {
                         continue;
                     }


### PR DESCRIPTION
fix "top -n 1" get  info like: 
[1m 32077 u0_a662   10 -10 7.0G 254M 119M R  104   3.3   4:42.38 com.xxx 

"[1m" is  ANSI escape code,  sometimes when you want to get COU rate, it will return 0 if use "startsWith()"