### PR TITLE
feat:修复首次安装自定义模块顺序不在第一行的问题(在没有进入自定义排序的情况下)

### DIFF
--- a/iOS/DoraemonKit/Src/Core/Cache/DoraemonCacheManager.m
+++ b/iOS/DoraemonKit/Src/Core/Cache/DoraemonCacheManager.m
@@ -415,7 +415,29 @@ static NSString * const kDoraemonHealthStartKey = @"doraemon_health_start_key";
         }
         [mutableDataArray addObjectsFromArray:[self kitShowManagerData]];
     }else{
-        mutableDataArray = dataArray;
+        NSMutableDictionary *mutableDic = [[NSMutableDictionary alloc] init];
+        for (NSDictionary *dic in dataArray) {
+            NSString *moduleName = dic[@"moduleName"];
+            if (moduleName && ([moduleName isEqualToString:DoraemonLocalizedString(@"常用工具")] ||
+                               [moduleName isEqualToString:DoraemonLocalizedString(@"性能检测")] ||
+                               [moduleName isEqualToString:DoraemonLocalizedString(@"视觉工具")] ||
+                               [moduleName isEqualToString:DoraemonLocalizedString(@"平台工具")] ||
+                               [moduleName isEqualToString:@"Weex"])) {
+                [mutableDataArray addObject:dic];
+                continue;
+            }
+            
+            NSArray *pluginArray = dic[@"pluginArray"];
+            NSMutableArray *mutablepluginArray = [[NSMutableArray alloc] init];
+            for (NSDictionary *subDic in pluginArray){
+                [mutablepluginArray addObject:subDic.mutableCopy];
+            }
+            [mutableDic setValue:dic[@"moduleName"] forKey:@"moduleName"];
+            [mutableDic setValue:mutablepluginArray forKey:@"pluginArray"];
+        }
+        if (mutableDic.allKeys.count) {
+            [mutableDataArray insertObject:mutableDic atIndex:0];
+        }
     }
     
     return mutableDataArray;


### PR DESCRIPTION
首次安装进入哆啦A梦首页，自定义模块跑到了最下面，当进入自定义排序页面后，自定义模块才会到最上面。
此处应该保证，自定义模块任何情况下都应该在第一行