### PR TITLE
【DoKit&北大开源实践】-【DoKit For Web】- 资源查看

### DIFF
--- a/Web/packages/web/src/plugins/resources/css/var.less
+++ b/Web/packages/web/src/plugins/resources/css/var.less
@@ -1,0 +1,13 @@
+
+// common
+@border-color:#f5f6f7;
+@border-active-color:#1485ee;
+@background-color: #ffffff;
+
+// console-tap
+@tap-height: 38px;
+@tap-font-size: 16px;
+@tap-font-color: #333333;
+
+// error
+

--- a/Web/packages/web/src/plugins/resources/index.js
+++ b/Web/packages/web/src/plugins/resources/index.js
@@ -1,0 +1,19 @@
+import Resources from './main.vue'
+import { RouterPlugin } from '@dokit/web-core'
+
+
+export default new RouterPlugin({
+    name: 'resources',
+    nameZh: '静态资源',
+    component: Resources,
+    icon: 'https://pt-starimg.didistatic.com/static/starimg/img/z1346TQD531618997547642.png',
+
+    onLoad() {
+        //console.log(window.performance.now())
+        console.log('resources')
+    },
+    onUnload() {
+
+    },
+
+})

--- a/Web/packages/web/src/plugins/resources/js/resources.js
+++ b/Web/packages/web/src/plugins/resources/js/resources.js
@@ -1,0 +1,183 @@
+export const ResourceMap = {
+    0: 'css',
+    1: 'script',
+    2: 'img',
+    3: 'other',
+}
+export const ResourceEnum = {
+    CSS: 0,
+    SCRIPT: 1,
+    IMG: 2,
+    OTHER: 3,
+}
+
+export const ResourceEntriesMap = {
+    'css': ResourceEnum.CSS,
+    'script': ResourceEnum.SCRIPT,
+    'img': ResourceEnum.IMG,
+    'other': ResourceEnum.OTHER,
+}
+
+export const Resource_METHODS = ["css", "script", "img"]
+
+export const ResourceTabs = Object.keys(ResourceMap).map(key => {
+    return {
+        type: parseInt(key),
+        name: ResourceMap[key]
+    }
+})
+
+export const regImg = /\.(jpeg|jpg|gif|png|bmp)$/
+export const regCss = /\.(css|less)$/
+
+export const isImg = (url) => regImg.test(url)
+export const isCss = (url) => regCss.test(url)
+
+export const getResourceEntries = function(callback) {
+    const performance = window.performance || window.webkitPerformance || window.msPerformance
+    if (performance && performance.getEntriesByType) {
+        const entries = performance.getEntriesByType("resource")
+            //const curtime = performance.now()
+        let arr = []
+        entries.forEach((entry) => {
+                let tmp = {
+                    initiatorType: entry.initiatorType,
+                    name: entry.name,
+                }
+                let flag = 0
+                for (let i = 0; i < arr.length; i += 1) {
+                    if (arr[i].initiatorType == tmp.initiatorType && arr[i].name == tmp.name) {
+                        flag = 1;
+                        break;
+                    }
+                }
+
+                if (!flag) arr.push(tmp)
+            })
+            //arr = Array.from(new Set(arr))
+        arr.forEach((entry) => {
+            let entryType = ResourceEntriesMap['other']
+            Resource_METHODS.forEach((type) => {
+                if (entry.initiatorType === type || (type === "img" && entry.initiatorType === "css" && isImg(entry.name)) || (type === "css" && isCss(entry.name))) {
+                    entryType = ResourceEntriesMap[type];
+                }
+            })
+            if (entryType === ResourceEntriesMap['img']) {
+                getBase64Image(entry.name, (res) => {
+                    callback({
+                        type: entryType,
+                        initiatorType: entry.initiatorType,
+                        entryName: entry.name,
+                        base64: res
+                    })
+                })
+            } else {
+                callback({
+                    type: entryType,
+                    initiatorType: entry.initiatorType,
+                    entryName: entry.name,
+                    base64: ''
+                })
+            }
+        })
+    }
+}
+
+export const imgLoad = function(url, callback) {
+    var img = new Image();
+    img.src = url;
+    if (img.complete) {
+        callback(img.width, img.height);
+    } else {
+        img.onload = function() {
+            callback(img.width, img.height);
+            img.onload = null;
+        };
+    };
+}
+
+export const getBase64Image = function(imgUrl, callback) {
+    var xhr = new XMLHttpRequest();
+    xhr.open("get", imgUrl, true);
+    xhr.responseType = "blob";
+    xhr.onload = function() {
+        if (this.status == 200) {
+            //得到一个blob对象
+            var blob = this.response;
+            //console.log("blob", blob)
+            let oFileReader = new FileReader();
+            oFileReader.onloadend = function(e) {
+                let base64 = e.target.result;
+                callback(base64)
+            };
+            oFileReader.readAsDataURL(blob);
+        } else {
+            callback('')
+        }
+    }
+    xhr.onerror = function(e) {
+        callback('')
+    }
+    xhr.send();
+}
+
+
+export const url2blob = function(file_url, callback) {
+    let xhr = new XMLHttpRequest();
+    xhr.open("get", file_url, true);
+    xhr.responseType = "blob";
+    xhr.onload = function() {
+        if (this.status == 200) {
+            const reader = new FileReader()
+            reader.onload = function() {
+                callback(reader.result)
+            }
+            reader.readAsText(this.response);
+        }
+    };
+    xhr.send();
+}
+
+export const url2blobPromise = function(file_url) {
+    return new Promise(function(resolve, reject) {
+        let xhr = new XMLHttpRequest();
+        xhr.open("get", file_url, true);
+        xhr.responseType = "blob";
+        xhr.onload = function() {
+            if (this.status == 200) {
+                //console.log(this.response)
+                const reader = new FileReader()
+                reader.onload = function() {
+                    resolve(reader.result)
+                }
+                reader.readAsText(this.response);
+            } else {
+                reject()
+            }
+        };
+        xhr.onerror = function(e) {
+            reject()
+        }
+        xhr.send();
+
+    });
+}
+
+export const trimLeft = function(s) {
+    if (s == null) {
+        return "";
+    }
+    var whitespace = new String(" \t\n\r");
+    var str = new String(s);
+    if (whitespace.indexOf(str.charAt(0)) != -1) {
+        var j = 0,
+            i = str.length;
+        while (j < i && whitespace.indexOf(str.charAt(j)) != -1) {
+            j++;
+        }
+        str = str.substring(j, i);
+        str = (new Array(j).join("&nbsp;")) + str
+
+    }
+    return str;
+}

--- a/Web/packages/web/src/plugins/resources/main.vue
+++ b/Web/packages/web/src/plugins/resources/main.vue
@@ -1,0 +1,86 @@
+<template>
+  <div class="all-resources-container">
+    <resource-tap :tabs="resourceTabs" @changeTap="handleChangeTab"></resource-tap>
+    <div class="resource-container">
+      <resource-container :resourceList = "curResourceList"></resource-container>
+    </div>
+  </div>
+</template>
+
+<script>
+import ResourceTap from './resource-tap';
+import ResourceContainer from './resource-container';
+import {ResourceTabs, ResourceEnum, getResourceEntries} from './js/resources';
+
+export default {
+  components: {
+    ResourceTap,
+    ResourceContainer,
+  },
+  data() {
+    return {
+      resourceTabs: ResourceTabs,
+      curTab: ResourceEnum.CSS,
+    }
+  },
+  computed:{
+    resourceList(){
+      let resourceList = this.$store.state.resourceList || [];
+      
+      return resourceList
+    },
+    curResourceList(){
+      return this.resourceList.filter(resource => {
+        return resource.type == this.curTab
+      })
+    },
+  },
+  created () {
+    //console.log(window.performance.now())
+  },
+  mounted (){
+    
+  },
+  activated(){
+    this.$nextTick(()=>{
+      let resourceList = [];
+      getResourceEntries(({ type, initiatorType, entryName, base64}) => {
+        resourceList.push({
+          type: type,
+          initiatorType: initiatorType,
+          entryName: entryName,
+          base64: base64
+        });
+      })
+      
+      this.$store.state.resourceList = resourceList
+    })
+  },
+  methods: {
+    handleChangeTab(type){
+      this.curTab = type
+      //console.log(this.$store.state.resourceList)
+    }
+  }
+}
+</script>
+
+<style lang="less" scoped>
+@import "./css/var.less";
+.all-resources-container{
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+.resource-container{
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  word-break: break-all;
+  overflow-y: scroll;
+  
+    background-color: @background-color;
+    border-bottom: 1px solid @border-color;
+    
+}
+</style>

--- a/Web/packages/web/src/plugins/resources/resource-container.vue
+++ b/Web/packages/web/src/plugins/resources/resource-container.vue
@@ -1,0 +1,38 @@
+<template>
+  <div class="resource-container">
+    <resource-item
+      v-for="(item, index) in resourceList"
+      :key="index"
+      :index="index"
+      :type="item.type"
+      :initiatorType="item.initiatorType"
+      :entryName="item.entryName"
+      :base64="item.base64"
+    ></resource-item>
+  </div>
+</template>
+<style lang="less" scoped>
+@import "./css/var.less";
+
+</style>
+<script>
+import ResourceItem from "./resource-item"
+export default{
+  components:{
+    ResourceItem
+  },
+  props: {
+    resourceList: {
+      type: Array,
+      default: [],
+    },
+  },
+  data() {
+    return {};
+  },
+  methods:{
+    
+
+  }
+}
+</script>

--- a/Web/packages/web/src/plugins/resources/resource-item.vue
+++ b/Web/packages/web/src/plugins/resources/resource-item.vue
@@ -1,0 +1,214 @@
+<template>
+  <div class="resource-ltem">
+    <div class="resource-preview" v-html="resourcePreview" @click="toggleDetail"></div>
+    <div v-if="canShowDetail">
+      <div class="resource-detail">
+        <div class="type" v-html="detailType"></div>
+        <div class="code" v-if="isCode" v-html="detailCode"></div>
+        <div class="img-thumb" v-if="isImg" v-html="detailImgThumb"></div>
+        <div class="img-size" v-if="isImg" v-html="detailImgSize"></div>
+      </div>
+      
+    </div>
+  </div>
+</template>
+<script>
+import {ResourceMap, imgLoad, url2blobPromise,trimLeft} from './js/resources'
+
+
+export default {
+  components: {
+
+  },
+  props: {
+    index: [Number],
+    type: [Number],
+    initiatorType: [String],
+    entryName: [String],
+    base64: [String],
+  },
+  data () {
+    return {
+      showDetail: false,
+      codehtml: `Loading...`,
+      imghtml: `Loading...`,
+      sizehtml: `Loading...`,
+      base64img:'',
+    }
+  },
+  computed: {
+    isImg(){
+      return ResourceMap[this.type]==="img"
+    },
+    isCode(){
+      return ResourceMap[this.type]==="css" || ResourceMap[this.type]==="script"
+    },
+    canShowDetail () {
+      return this.showDetail
+    },
+    detailType(){
+      let typehtml = `initiatorType:${this.initiatorType}`
+      return typehtml
+    },
+    detailImgThumb(){
+      let url;
+      if(this.base64 !== ""){
+        url = this.base64
+      }else{
+        url = this.entryName
+      }
+      this.imghtml = `<img src = "${url}" style="object-fit: cover;height:100px" />`
+      return this.imghtml
+    },
+    detailImgSize(){
+      let url;
+      if(this.base64 !== ""){
+        url = this.base64
+      }else{
+        url = this.entryName
+      }
+      imgLoad(url, (w, h) =>{
+        this.sizehtml =  `${w}*${h}`
+      })
+      return this.sizehtml
+    },
+    detailCode(){
+      url2blobPromise(this.entryName).then((res)=>{
+          res = res.replace(/</g,'&lt;')
+          res = res.replace(/>/g,'&gt;')
+          let tmp = res
+          tmp = tmp.split('\n')
+          let len  = tmp.length
+          let r = ``
+          for(let i=0; i<len; i=i+1){
+            tmp[i] = trimLeft(tmp[i])
+            r += `<div class="codeline" style="display:flex;"><div class="codeindex" style="min-width: 40px;color: #1485ee;">${i+1}</div><div class="codevalue">${tmp[i]}</div></div>`
+          }
+          this.codehtml = r
+          
+        }).catch(()=>{
+          this.codehtml = `fail to load resource`
+        })
+      return this.codehtml
+    },
+    resourcePreview () {
+      let index = this.index
+      let url = this.entryName
+      let html = `<div>${index+1}.${url}</div>`
+      return html
+    },
+    resourceDetail () {
+     
+      let type = ResourceMap[this.type]
+      let url = this.entryName
+      let initiatorType = this.initiatorType
+      let typehtml = `<div class="type">initiatorType:${initiatorType}</div>`
+
+      
+      if(type === 'script' || type === 'css'){
+        
+        url2blobPromise(url).then((res)=>{
+          res = res.replace(/</g,'&lt;')
+          res = res.replace(/>/g,'&gt;')
+          let tmp = res
+          tmp = tmp.split('\n')
+          let len  = tmp.length
+          let r = ``
+          for(let i=0; i<len; i=i+1){
+            tmp[i] = trimLeft(tmp[i])
+            r += `<div class="codeline"><div class="codeindex">${i+1}</div><div class="codevalue">${tmp[i]}</div></div>`
+          }
+          this.codehtml = `<div class="code">`+r+`</div>`
+        }).catch(()=>{
+          this.codehtml = `<div class="code">fail to load resource</div>`
+        })
+        return typehtml + this.codehtml
+        
+      }
+      
+      else if(type === 'img'){
+        
+        if(this.base64 !== ""){
+          this.imghtml = `<img src = "${this.base64}" class = "img-thumb" />`
+          imgLoad(this.base64, (w, h) =>{
+            this.sizehtml =  `<div class="img-size">${w}*${h}</div>`
+          })
+        }
+        else{
+          this.imghtml = `<img src = "${url}" class = "img-thumb" />`
+          imgLoad(url, (w, h) =>{
+            this.sizehtml =  `<div class="img-size">${w}*${h}</div>`
+          })
+        }
+        return typehtml+this.imghtml+this.sizehtml
+      }
+      else if(type === 'other'){
+        typehtml = `<div class="type" style="border:0">initiatorType:${initiatorType}</div>`
+        return typehtml
+      }
+      
+    }
+  },
+
+  methods: {
+    toggleDetail () {
+      this.showDetail = !this.showDetail
+    },
+  }
+}
+</script>
+<style lang="less" scoped>
+  .resource-ltem{
+    padding: 10px 20px;
+    border-top: 1px solid #eee;
+    text-align: left;
+    font-size: 12px;
+  }
+  .resource-ltem:first-child {
+    border: none;
+  }
+  .resource-ltem:nth-of-type(odd){
+    background:#f3f3f3;
+  }
+  .resource-preview{
+    
+  }
+
+  .resource-detail {
+    margin: 5px 10px;
+    border: 1px solid gray;
+    text-align: center;
+    .type  {
+      padding: 5px 10px;
+      font-size: 12px;
+      text-align: center;
+    }
+    .code{
+      border-top: 1px solid gray;
+      padding: 10px 10px;
+      max-height: 300px;
+      overflow-y: scroll;
+      text-align: left;
+      .codeline{
+        display: flex;
+        flex: 1;
+        .codeindex{
+          min-width: 40px;
+          color: #1485ee;
+        }
+        .codevalue{
+          
+        }
+      }
+    }
+    .img-thumb{
+      border-top: 1px solid gray;
+      padding: 5px 0px;
+      height: 100px;
+    }
+    .img-size{
+      padding:5px 0px;
+    }
+  }
+  
+</style>

--- a/Web/packages/web/src/plugins/resources/resource-tap.vue
+++ b/Web/packages/web/src/plugins/resources/resource-tap.vue
@@ -1,0 +1,64 @@
+<template>
+  <div class="tab-container">
+    <div class="tab-list">
+      <div
+        class="tab-item"
+        :class="curIndex === index? 'tab-active': 'tab-default'"
+        v-for="(item, index) in tabs"
+        :key="index"
+        @click="handleClickTab(item, index)"
+      >
+        <span class="tab-item-text">{{ item.name }}</span>
+      </div>
+    </div>
+  </div>
+</template>
+<style lang="less" scoped>
+@import "./css/var.less";
+.tab-container{
+  .tab-list{
+    display: flex;
+    height: @tap-height;
+    justify-content: space-between;
+    align-items: center;
+    border: 1px solid @border-color;
+  }
+  .tab-item{
+    flex: 1;
+    height: @tap-height;
+    line-height: @tap-height;
+    text-align: center;
+  }
+  .tab-item-text{
+    font-size: @tap-font-size;
+    color: @tap-font-color;
+  }
+  .tab-active{
+    border-bottom: 1px solid @border-active-color;
+  }
+  .tab-default{
+    border: none;
+  }
+}
+</style>
+<script>
+export default {
+  props: {
+    tabs: {
+      type: Array
+    },
+  },
+  data() {
+    return {
+      curIndex: 0
+    };
+  },
+  methods: {
+    handleClickTab(item, index) {
+      let { type } = item;
+      this.curIndex = index;
+      this.$emit("changeTap", type);
+    },
+  },
+};
+</script>


### PR DESCRIPTION
DoKit For Web 的 resources（资源查看）插件

功能：
分别展示css、script、img、其他类型资源。
默认显示所有资源的url，点击url可显示详细信息，例如initiatorType，css、script类型的详细代码，img类型的缩略图和图片尺寸

原理：
通过window.performance.getEntriesByType("resource")读取所有页面上的所有资源，产生resourceList，根据initiatorType和一些特判规则将资源分为css、script、img、other四类，展示在四个标签页中。
在每次打开“资源查看”插件时，更新resourceList并去重。
在生成resourceList的时候，获取所有图片的base64值并存储，在需要显示图片详情时通过base64访问，减少网络请求。
在需要显示css或script代码详情时，请求获取文本，并显示为带行号和缩进的样式。

作者：Zhang Xinyu

截图：
![8461622343117_ pic_hd](https://user-images.githubusercontent.com/48897310/120090877-8e05b480-c138-11eb-9b3c-9efd54a127e2.jpg)
![8451622343106_ pic_hd](https://user-images.githubusercontent.com/48897310/120090892-a4ac0b80-c138-11eb-8cc1-419586a24ed5.jpg)
![8471622343131_ pic_hd](https://user-images.githubusercontent.com/48897310/120090898-afff3700-c138-11eb-9650-0dc31091af4a.jpg)
![8481622343145_ pic_hd](https://user-images.githubusercontent.com/48897310/120090906-b7bedb80-c138-11eb-95f4-fdb33f38ca2e.jpg)
