### PR TITLE
【DoKit&北大开源实践】-【DoKit For IOS】- 查看动图信息插件

### DIFF
--- a/iOS/DoraemonKitDemo/DoraemonKitDemo.xcodeproj/project.pbxproj
+++ b/iOS/DoraemonKitDemo/DoraemonKitDemo.xcodeproj/project.pbxproj
@@ -18,6 +18,11 @@
 		0AC7509C246A8EE100F87363 /* WebpDemo.webp in Resources */ = {isa = PBXBuildFile; fileRef = 0AC7509B246A8B4900F87363 /* WebpDemo.webp */; };
 		0AFBC55223BAE6F80099A8BD /* DoraemonDemoNetTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 0AFBC55023BAE6F80099A8BD /* DoraemonDemoNetTableViewCell.m */; };
 		B65C2263AF96F94C50A222DF /* libPods-DoraemonKitDemo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 29E964A2D92411C9DC5482EF /* libPods-DoraemonKitDemo.a */; };
+		C412C99526514C3200A3B526 /* UIImageView+GIFProperty.m in Sources */ = {isa = PBXBuildFile; fileRef = C412C99426514C3200A3B526 /* UIImageView+GIFProperty.m */; };
+		C412C9AA265298CE00A3B526 /* GIFInfoView.m in Sources */ = {isa = PBXBuildFile; fileRef = C412C9A9265298CE00A3B526 /* GIFInfoView.m */; };
+		C412C9AE2652991500A3B526 /* GIFInfoWindow.m in Sources */ = {isa = PBXBuildFile; fileRef = C412C9AD2652991500A3B526 /* GIFInfoWindow.m */; };
+		C412C9B0265372FD00A3B526 /* UIWebViewDemo.m in Sources */ = {isa = PBXBuildFile; fileRef = C412C9AF265372FD00A3B526 /* UIWebViewDemo.m */; };
+		C472FCE326634FC900CA0BE1 /* GifInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = C472FCE226634FC900CA0BE1 /* GifInfo.m */; };
 		DA0C6F331FDEBC2E00F43588 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DA0C6F311FDEBC2E00F43588 /* LaunchScreen.storyboard */; };
 		DA0C6F3A1FDEBE3800F43588 /* TestPlugin.m in Sources */ = {isa = PBXBuildFile; fileRef = DA0C6F391FDEBE3800F43588 /* TestPlugin.m */; };
 		DA4AD81A224E0EC8006F767C /* Doraemon.docx in Resources */ = {isa = PBXBuildFile; fileRef = DA4AD817224E0EC8006F767C /* Doraemon.docx */; };
@@ -69,6 +74,16 @@
 		0AFBC55023BAE6F80099A8BD /* DoraemonDemoNetTableViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DoraemonDemoNetTableViewCell.m; sourceTree = "<group>"; };
 		0AFBC55123BAE6F80099A8BD /* DoraemonDemoNetTableViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DoraemonDemoNetTableViewCell.h; sourceTree = "<group>"; };
 		29E964A2D92411C9DC5482EF /* libPods-DoraemonKitDemo.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-DoraemonKitDemo.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		C412C99326514C3200A3B526 /* UIImageView+GIFProperty.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIImageView+GIFProperty.h"; sourceTree = "<group>"; };
+		C412C99426514C3200A3B526 /* UIImageView+GIFProperty.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIImageView+GIFProperty.m"; sourceTree = "<group>"; };
+		C412C9A9265298CE00A3B526 /* GIFInfoView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = GIFInfoView.m; sourceTree = "<group>"; };
+		C412C9AB265298E400A3B526 /* GIFInfoView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GIFInfoView.h; sourceTree = "<group>"; };
+		C412C9AC2652990200A3B526 /* GIFInfoWindow.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GIFInfoWindow.h; sourceTree = "<group>"; };
+		C412C9AD2652991500A3B526 /* GIFInfoWindow.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = GIFInfoWindow.m; sourceTree = "<group>"; };
+		C412C9AF265372FD00A3B526 /* UIWebViewDemo.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = UIWebViewDemo.m; sourceTree = "<group>"; };
+		C412C9B12653732A00A3B526 /* UIWebViewDemo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UIWebViewDemo.h; sourceTree = "<group>"; };
+		C472FCE126634FC900CA0BE1 /* GifInfo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GifInfo.h; sourceTree = "<group>"; };
+		C472FCE226634FC900CA0BE1 /* GifInfo.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = GifInfo.m; sourceTree = "<group>"; };
 		DA0C6F321FDEBC2E00F43588 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		DA0C6F381FDEBE3800F43588 /* TestPlugin.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TestPlugin.h; sourceTree = "<group>"; };
 		DA0C6F391FDEBE3800F43588 /* TestPlugin.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TestPlugin.m; sourceTree = "<group>"; };
@@ -193,9 +208,35 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		C412C99B2652960C00A3B526 /* testGif */ = {
+			isa = PBXGroup;
+			children = (
+				C412C99C2652964200A3B526 /* function */,
+				C412C99426514C3200A3B526 /* UIImageView+GIFProperty.m */,
+				C412C99326514C3200A3B526 /* UIImageView+GIFProperty.h */,
+				C472FCE126634FC900CA0BE1 /* GifInfo.h */,
+				C472FCE226634FC900CA0BE1 /* GifInfo.m */,
+			);
+			path = testGif;
+			sourceTree = "<group>";
+		};
+		C412C99C2652964200A3B526 /* function */ = {
+			isa = PBXGroup;
+			children = (
+				C412C9A9265298CE00A3B526 /* GIFInfoView.m */,
+				C412C9AB265298E400A3B526 /* GIFInfoView.h */,
+				C412C9AC2652990200A3B526 /* GIFInfoWindow.h */,
+				C412C9AD2652991500A3B526 /* GIFInfoWindow.m */,
+				C412C9AF265372FD00A3B526 /* UIWebViewDemo.m */,
+				C412C9B12653732A00A3B526 /* UIWebViewDemo.h */,
+			);
+			path = function;
+			sourceTree = "<group>";
+		};
 		DA0C6F371FDEBE2500F43588 /* Plugin */ = {
 			isa = PBXGroup;
 			children = (
+				C412C99B2652960C00A3B526 /* testGif */,
 				DA0C6F381FDEBE3800F43588 /* TestPlugin.h */,
 				DA0C6F391FDEBE3800F43588 /* TestPlugin.m */,
 				DAD46BD81FE6B7AF00E3E7BC /* StartPlugin.h */,
@@ -556,16 +597,20 @@
 				DAFE052D21BD4A4D00F97A59 /* DoraemonDemoMockGPSAnnotation.m in Sources */,
 				DAFE052921BD4A4D00F97A59 /* DoraemonDemoCrashViewController.m in Sources */,
 				DA0C6F3A1FDEBE3800F43588 /* TestPlugin.m in Sources */,
+				C472FCE326634FC900CA0BE1 /* GifInfo.m in Sources */,
 				DABBE3B221D3AA260070518E /* DoraemonUIWebViewViewController.m in Sources */,
 				0A5399852349ED5B00C47CB3 /* DoraemonDemoMemoryLeakViewController.m in Sources */,
 				0A5399882349EE7E00C47CB3 /* DoraemonDemoMemoryLeakModel.m in Sources */,
+				C412C9AA265298CE00A3B526 /* GIFInfoView.m in Sources */,
 				DAFE052C21BD4A4D00F97A59 /* DoraemonDemoCommonViewController.m in Sources */,
 				0AFBC55223BAE6F80099A8BD /* DoraemonDemoNetTableViewCell.m in Sources */,
 				0AA262E1240F8AC400BF144F /* DoraemonDemoBaseViewController.m in Sources */,
+				C412C9AE2652991500A3B526 /* GIFInfoWindow.m in Sources */,
 				DAFE052A21BD4A4D00F97A59 /* DoraemonDemoCrashMRCView.m in Sources */,
 				0A6CF27C2438BDDD00A2CBF4 /* DoraemonKitDemoi18Util.m in Sources */,
 				DAC3FA7622B8DD7400871E5C /* DoraemonDemoImageViewController.m in Sources */,
 				DAC3FA7922B8E0EE00871E5C /* DoraemonDemoImageShowViewController.m in Sources */,
+				C412C99526514C3200A3B526 /* UIImageView+GIFProperty.m in Sources */,
 				DAC8A87C1FDE2C3B00F03E6F /* DoKitAppDelegate.m in Sources */,
 				DAFE052821BD4A4D00F97A59 /* DoraemonDemoLoggerViewController.m in Sources */,
 				DAFE052E21BD4A4D00F97A59 /* DoraemonDemoMockGPSViewController.m in Sources */,
@@ -573,6 +618,7 @@
 				0A6C9CED2423219400BAEF5E /* DoraemonDemoURLProtocol2.m in Sources */,
 				0A53998B2349EE9500C47CB3 /* DoraemonDemoMemoryLeakView.m in Sources */,
 				DAFE052521BD4A4D00F97A59 /* DoraemonDemoUIViewController.m in Sources */,
+				C412C9B0265372FD00A3B526 /* UIWebViewDemo.m in Sources */,
 				DAD46BDA1FE6B7AF00E3E7BC /* StartPlugin.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/iOS/DoraemonKitDemo/DoraemonKitDemo/DoKitAppDelegate.m
+++ b/iOS/DoraemonKitDemo/DoraemonKitDemo/DoKitAppDelegate.m
@@ -43,6 +43,8 @@
     }
     [[DoraemonManager shareInstance] addPluginWithTitle:DoraemonDemoLocalizedString(@"测试插件") icon:@"doraemon_default" desc:DoraemonDemoLocalizedString(@"测试插件") pluginName:@"TestPlugin" atModule:DoraemonDemoLocalizedString(@"业务工具")];
 
+    [[DoraemonManager shareInstance] addPluginWithTitle:DoraemonDemoLocalizedString(@"GifInfo") icon:@"doraemon_default" desc:DoraemonDemoLocalizedString(@"GIF图片信息显示插件") pluginName:@"GifInfo" atModule:DoraemonDemoLocalizedString(@"业务工具")];
+    
     [[DoraemonManager shareInstance] addPluginWithTitle:DoraemonDemoLocalizedString(@"block方式加入插件") icon:@"doraemon_default" desc:@"测试插件" pluginName:@"pluginName" atModule:DoraemonDemoLocalizedString(@"业务工具") handle:^(NSDictionary *itemData) {
         NSLog(@"handle block plugin");
     }];

--- a/iOS/DoraemonKitDemo/DoraemonKitDemo/Plugin/testGif/GifInfo.h
+++ b/iOS/DoraemonKitDemo/DoraemonKitDemo/Plugin/testGif/GifInfo.h
@@ -1,0 +1,20 @@
+//
+//  GifInfo.h
+//  DoraemonKitDemo
+//
+//  Created by 宋迪 on 2021/5/30.
+//  Copyright © 2021 yixiang. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "DoraemonPluginProtocol.h"
+#import <DoraemonKit/DoraemonPluginProtocol.h>
+#import "UIImageView+GIFProperty.h"
+#import "DoraemonDemoBaseViewController.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface GifInfo : DoraemonDemoBaseViewController
+@end
+
+NS_ASSUME_NONNULL_END

--- a/iOS/DoraemonKitDemo/DoraemonKitDemo/Plugin/testGif/GifInfo.m
+++ b/iOS/DoraemonKitDemo/DoraemonKitDemo/Plugin/testGif/GifInfo.m
@@ -1,0 +1,32 @@
+//
+//  GifInfo.m
+//  DoraemonKitDemo
+//
+//  Created by 宋迪 on 2021/5/30.
+//  Copyright © 2021 yixiang. All rights reserved.
+//
+
+#import "GifInfo.h"
+#import "UIImageView+GIFProperty.h"
+#import "DoraemonHomeWindow.h"
+#import "GIFInfoWindow.h"
+#import "GIFInfoView.h"
+#import "UIWebViewDemo.h"
+
+@implementation GifInfo
+    UIWebView *webview1;
+- (void)pluginDidLoad {
+    [super viewDidLoad];
+    //[[DoraemonColorPickWindow shareInstance] show];
+    [[GIFInfoWindow shareInstance] show];
+    [[DoraemonHomeWindow shareInstance] hide];
+    NSLog(@"what?");
+    UIViewController *vc = [[UIWebViewDemo alloc] init];
+    [DoraemonHomeWindow openPlugin:vc];
+    
+}
+- (void)openUIWebView{
+    UIViewController *vc = [[UIWebViewDemo alloc] init];
+    [self.navigationController pushViewController:vc animated:YES];
+}
+@end

--- a/iOS/DoraemonKitDemo/DoraemonKitDemo/Plugin/testGif/UIImageView+GIFProperty.h
+++ b/iOS/DoraemonKitDemo/DoraemonKitDemo/Plugin/testGif/UIImageView+GIFProperty.h
@@ -1,0 +1,20 @@
+//
+//  UIImageView+GIFProperty.h
+//  DoraemonKitDemo
+//
+//  Created by 宋迪 on 2021/5/16.
+//  Copyright © 2021 yixiang. All rights reserved.
+//
+
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface UIImageView (GIFProperty)
+-(NSTimeInterval)durationForGifData:(NSData *)data;//获取gif动画总时长
+-(NSInteger)repeatCountForGifData:(NSData *)data;//获取gif动画循环总次数 0:表示无限循环
+-(NSInteger)GifFrameCount:(NSDate *)data;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/iOS/DoraemonKitDemo/DoraemonKitDemo/Plugin/testGif/UIImageView+GIFProperty.m
+++ b/iOS/DoraemonKitDemo/DoraemonKitDemo/Plugin/testGif/UIImageView+GIFProperty.m
@@ -1,0 +1,138 @@
+//
+//  UIImageView+GIFProperty.m
+//  DoraemonKitDemo
+//
+//  Created by 宋迪 on 2021/5/16.
+//  Copyright © 2021 yixiang. All rights reserved.
+//
+
+
+#import "UIImageView+GIFProperty.h"
+
+@implementation UIImageView (GIFProperty)
+
+- (NSInteger)GifFrameCount:(NSData *)data{
+    
+    //将GIF图片转换成对应的图片源
+    CGImageSourceRef gifSource = CGImageSourceCreateWithData((__bridge CFDataRef)data, NULL);
+    
+    //获取其中图片源个数，即由多少帧图片组成
+    size_t frameCout = CGImageSourceGetCount(gifSource);
+
+    //定义数组存储拆分出来的图片
+    NSMutableArray* frames = [[NSMutableArray alloc] init];
+    NSTimeInterval totalDuration = 0;
+    //NSLog(@"%d",frameCout);
+    for (size_t i=0; i<frameCout; i++) {
+
+        //从GIF图片中取出源图片
+        CGImageRef imageRef = CGImageSourceCreateImageAtIndex(gifSource, i, NULL);
+
+        //将图片源转换成UIimageView能使用的图片源
+        UIImage* imageName = [UIImage imageWithCGImage:imageRef];
+
+        //将图片加入数组中
+        [frames addObject:imageName];
+        NSTimeInterval duration = [self gifImageDeleyTime:gifSource index:i];
+        totalDuration += duration;
+        CGImageRelease(imageRef);
+    }
+    
+    //获取帧数
+    return frameCout;
+}
+
+
+//获取gif图片的总时长
+- (NSTimeInterval)durationForGifData:(NSData *)data{
+    
+    //将GIF图片转换成对应的图片源
+    CGImageSourceRef gifSource = CGImageSourceCreateWithData((__bridge CFDataRef)data, NULL);
+    
+    //获取其中图片源个数，即由多少帧图片组成
+    size_t frameCout = CGImageSourceGetCount(gifSource);
+
+    //定义数组存储拆分出来的图片
+    NSMutableArray* frames = [[NSMutableArray alloc] init];
+    NSTimeInterval totalDuration = 0;
+    //NSLog(@"%d",frameCout);
+    for (size_t i=0; i<frameCout; i++) {
+
+        //从GIF图片中取出源图片
+        CGImageRef imageRef = CGImageSourceCreateImageAtIndex(gifSource, i, NULL);
+
+        //将图片源转换成UIimageView能使用的图片源
+        UIImage* imageName = [UIImage imageWithCGImage:imageRef];
+
+        //将图片加入数组中
+        [frames addObject:imageName];
+        NSTimeInterval duration = [self gifImageDeleyTime:gifSource index:i];
+        totalDuration += duration;
+        CGImageRelease(imageRef);
+    }
+    
+    //获取循环次数
+    NSInteger loopCount = 0;//循环次数
+    CFDictionaryRef properties = CGImageSourceCopyProperties(gifSource, NULL);
+    if (properties) {
+        CFDictionaryRef gif = CFDictionaryGetValue(properties, kCGImagePropertyGIFDictionary);
+        if (gif) {
+            CFTypeRef loop = CFDictionaryGetValue(gif, kCGImagePropertyGIFLoopCount);
+            if (loop) {
+                //如果loop == NULL，表示不循环播放，当loopCount  == 0时，表示无限循环；
+                CFNumberGetValue(loop, kCFNumberNSIntegerType, &loopCount);
+            };
+        }
+    }
+    CFRelease(gifSource);
+    return totalDuration;
+}
+
+//获取gif图片的循环次数
+-(NSInteger)repeatCountForGifData:(NSData *)data{
+    
+    //将GIF图片转换成对应的图片源
+    CGImageSourceRef gifSource = CGImageSourceCreateWithData((__bridge CFDataRef)data, NULL);
+    
+    //获取循环次数
+    NSInteger loopCount = 0;//循环次数
+    CFDictionaryRef properties = CGImageSourceCopyProperties(gifSource, NULL);
+    if (properties) {
+        CFDictionaryRef gif = CFDictionaryGetValue(properties, kCGImagePropertyGIFDictionary);
+        if (gif) {
+            CFTypeRef loop = CFDictionaryGetValue(gif, kCGImagePropertyGIFLoopCount);
+            if (loop) {
+                //如果loop == NULL，表示不循环播放，当loopCount  == 0时，表示无限循环；
+                CFNumberGetValue(loop, kCFNumberNSIntegerType, &loopCount);
+            };
+        }
+    }
+    CFRelease(gifSource);
+    
+    return loopCount;
+}
+
+//获取GIF图片每帧的时长
+- (NSTimeInterval)gifImageDeleyTime:(CGImageSourceRef)imageSource index:(NSInteger)index {
+    NSTimeInterval duration = 0;
+    CFDictionaryRef imageProperties = CGImageSourceCopyPropertiesAtIndex(imageSource, index, NULL);
+    if (imageProperties) {
+        CFDictionaryRef gifProperties;
+        BOOL result = CFDictionaryGetValueIfPresent(imageProperties, kCGImagePropertyGIFDictionary, (const void **)&gifProperties);
+        if (result) {
+            const void *durationValue;
+            if (CFDictionaryGetValueIfPresent(gifProperties, kCGImagePropertyGIFUnclampedDelayTime, &durationValue)) {
+                duration = [(__bridge NSNumber *)durationValue doubleValue];
+                if (duration <= 0) {
+                    if (CFDictionaryGetValueIfPresent(gifProperties, kCGImagePropertyGIFDelayTime, &durationValue)) {
+                        duration = [(__bridge NSNumber *)durationValue doubleValue];
+                    }
+                }
+            }
+        }
+    }
+    
+    return duration;
+}
+
+@end

--- a/iOS/DoraemonKitDemo/DoraemonKitDemo/Plugin/testGif/function/GIFInfoView.h
+++ b/iOS/DoraemonKitDemo/DoraemonKitDemo/Plugin/testGif/function/GIFInfoView.h
@@ -1,0 +1,35 @@
+//
+//  GIFInfoView.h
+//  DoraemonKitDemo
+//
+//  Created by 宋迪 on 2021/5/17.
+//  Copyright © 2021 yixiang. All rights reserved.
+//
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+@class GIFInfoView;
+
+// 协议？没有实现具体定义
+@protocol GIFInfoViewDelegate <NSObject>
+
+@optional
+// 点击关闭按钮
+- (void)closeBtnClicked:(id)sender onColorPickInfoView:(GIFInfoView *)colorPickInfoView;
+
+@end
+
+@interface GIFInfoView : UIView
+
+// 属性声明？property
+@property (nonatomic, weak) id<GIFInfoViewDelegate> delegate;
+
+// 设置timelast和帧数
+- (void)setTimeLast:(NSString *)timeLast;
+- (void)setFrameCount:(NSString *)frameCount;
+- (void)setUrlInfo:(NSString *)UrlInfo;
+- (void)setGifImageSize:(NSString *)GifImageSize;
+@end
+
+NS_ASSUME_NONNULL_END
+

--- a/iOS/DoraemonKitDemo/DoraemonKitDemo/Plugin/testGif/function/GIFInfoView.m
+++ b/iOS/DoraemonKitDemo/DoraemonKitDemo/Plugin/testGif/function/GIFInfoView.m
@@ -1,0 +1,183 @@
+//
+//  GIFInfoView.m
+//  DoraemonKitDemo
+//
+//  Created by 宋迪 on 2021/5/17.
+//  Copyright © 2021 yixiang. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "GIFInfoView.h"
+#import "DoraemonDefine.h"
+
+@interface GIFInfoView ()
+
+@property (nonatomic, strong) UILabel *timelastLbl;
+@property (nonatomic, strong) UILabel *framcountLbl;
+@property (nonatomic, strong) UILabel *urlinfoLbl;
+@property (nonatomic, strong) UILabel *gifimagesizeLbl;
+@property (nonatomic, strong) UIButton *closeBtn;
+
+@end
+
+@implementation GIFInfoView
+
+#pragma mark - Lifecycle
+
+- (instancetype)initWithFrame:(CGRect)frame {
+    self = [super initWithFrame:frame];
+    if (self) {
+        [self commonInit];
+    }
+    return self;
+}
+
+- (void)commonInit {
+#if defined(__IPHONE_13_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0)
+    if (@available(iOS 13.0, *)) {
+        self.backgroundColor = [UIColor colorWithDynamicProvider:^UIColor * _Nonnull(UITraitCollection * _Nonnull traitCollection) {
+            if (traitCollection.userInterfaceStyle == UIUserInterfaceStyleLight) {
+                return [UIColor whiteColor];
+            } else {
+                return [UIColor secondarySystemBackgroundColor];
+            }
+        }];
+    } else {
+#endif
+        self.backgroundColor = [UIColor whiteColor];
+#if defined(__IPHONE_13_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0)
+    }
+#endif
+    self.layer.cornerRadius = kDoraemonSizeFrom750_Landscape(8);
+    self.layer.borderWidth = 1.;
+    self.layer.borderColor = [UIColor doraemon_colorWithHex:0x999999 andAlpha:0.2].CGColor;
+    
+    //[self addSubview:self.colorView];
+    [self addSubview:self.timelastLbl];
+    [self addSubview:self.framcountLbl];
+    [self addSubview:self.urlinfoLbl];
+    [self addSubview:self.gifimagesizeLbl];
+    [self addSubview:self.closeBtn];
+}
+
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
+    [super traitCollectionDidChange:previousTraitCollection];
+    // trait发生了改变
+#if defined(__IPHONE_13_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0)
+    if (@available(iOS 13.0, *)) {
+        if ([self.traitCollection hasDifferentColorAppearanceComparedToTraitCollection:previousTraitCollection]) {
+            if (UITraitCollection.currentTraitCollection.userInterfaceStyle == UIUserInterfaceStyleDark) {
+                [self.closeBtn setImage:[UIImage doraemon_xcassetImageNamed:@"doraemon_close_dark"] forState:UIControlStateNormal];
+            } else {
+                [self.closeBtn setImage:[UIImage doraemon_xcassetImageNamed:@"doraemon_close"] forState:UIControlStateNormal];
+            }
+        }
+    }
+#endif
+}
+
+#pragma mark - Layout
+
+- (void)layoutSubviews {
+    [super layoutSubviews];
+    
+//    CGFloat colorWidth = kDoraemonSizeFrom750_Landscape(28);
+//    CGFloat colorHeight = kDoraemonSizeFrom750_Landscape(28);
+//    self.colorView.frame = CGRectMake(kDoraemonSizeFrom750_Landscape(32), (self.doraemon_height - colorHeight) / 2.0, colorWidth, colorHeight);
+    
+    CGFloat colorValueWidth = kDoraemonSizeFrom750_Landscape(400);
+    self.timelastLbl.frame = CGRectMake(kDoraemonSizeFrom750_Landscape(30), kDoraemonSizeFrom750_Landscape(-100), colorValueWidth, self.doraemon_height);
+    self.framcountLbl.frame = CGRectMake(kDoraemonSizeFrom750_Landscape(30), kDoraemonSizeFrom750_Landscape(-50), colorValueWidth, self.doraemon_height);
+    self.urlinfoLbl.frame = CGRectMake(kDoraemonSizeFrom750_Landscape(30), kDoraemonSizeFrom750_Landscape(70), kDoraemonSizeFrom750_Landscape(600), self.doraemon_height);
+    self.gifimagesizeLbl.frame = CGRectMake(kDoraemonSizeFrom750_Landscape(30), kDoraemonSizeFrom750_Landscape(0), colorValueWidth, self.doraemon_height);
+    
+    CGFloat closeWidth = kDoraemonSizeFrom750_Landscape(44);
+    CGFloat closeHeight = kDoraemonSizeFrom750_Landscape(44);
+    self.closeBtn.frame = CGRectMake(self.doraemon_width - closeWidth - kDoraemonSizeFrom750_Landscape(32), (self.doraemon_height - closeHeight) / 2.0, closeWidth, closeHeight);
+}
+
+#pragma mark - Public
+
+- (void)setTimeLast:(NSString *)timeLast{
+    self.timelastLbl.text = timeLast;
+}
+
+- (void)setFrameCount:(NSString *)frameCount{
+    self.framcountLbl.text = frameCount;
+}
+
+- (void)setUrlInfo:(NSString *)UrlInfo{
+    self.urlinfoLbl.text = UrlInfo;
+}
+
+- (void)setGifImageSize:(NSString *)GifImageSize{
+    self.gifimagesizeLbl.text = GifImageSize;
+}
+#pragma mark - Actions
+
+- (void)closeBtnClicked:(id)sender {
+    if ([self.delegate respondsToSelector:@selector(closeBtnClicked:onColorPickInfoView:)]) {
+        [self.delegate closeBtnClicked:sender onColorPickInfoView:self];
+    }
+}
+
+
+
+#pragma mark - Getter
+
+
+- (UILabel *)timelastLbl {
+    if (!_timelastLbl) {
+        _timelastLbl = [[UILabel alloc] init];
+        _timelastLbl.textColor = [UIColor doraemon_black_1];
+        _timelastLbl.font = [UIFont systemFontOfSize:kDoraemonSizeFrom750_Landscape(28)];
+    }
+    return _timelastLbl;
+}
+
+- (UILabel *)framcountLbl {
+    if (!_framcountLbl) {
+        _framcountLbl = [[UILabel alloc] init];
+        _framcountLbl.textColor = [UIColor doraemon_black_1];
+        _framcountLbl.font = [UIFont systemFontOfSize:kDoraemonSizeFrom750_Landscape(28)];
+    }
+    return _framcountLbl;
+}
+
+- (UILabel *)urlinfoLbl {
+    if (!_urlinfoLbl) {
+        _urlinfoLbl = [[UILabel alloc] init];
+        _urlinfoLbl.textColor = [UIColor doraemon_black_1];
+        _urlinfoLbl.font = [UIFont systemFontOfSize:kDoraemonSizeFrom750_Landscape(28)];
+        _urlinfoLbl.lineBreakMode = NSLineBreakByWordWrapping;
+        _urlinfoLbl.numberOfLines = 0;
+    }
+    return _urlinfoLbl;
+}
+- (UILabel *)gifimagesizeLbl {
+    if (!_gifimagesizeLbl) {
+        _gifimagesizeLbl = [[UILabel alloc] init];
+        _gifimagesizeLbl.textColor = [UIColor doraemon_black_1];
+        _gifimagesizeLbl.font = [UIFont systemFontOfSize:kDoraemonSizeFrom750_Landscape(28)];
+    }
+    return _gifimagesizeLbl;
+}
+
+- (UIButton *)closeBtn {
+    if (!_closeBtn) {
+        _closeBtn = [[UIButton alloc] init];
+        UIImage *closeImage = [UIImage doraemon_xcassetImageNamed:@"doraemon_close"];
+#if defined(__IPHONE_13_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0)
+        if (@available(iOS 13.0, *)) {
+            if (UITraitCollection.currentTraitCollection.userInterfaceStyle == UIUserInterfaceStyleDark) {
+                closeImage = [UIImage doraemon_xcassetImageNamed:@"doraemon_close_dark"];
+            }
+        }
+#endif
+        [_closeBtn setBackgroundImage:closeImage forState:UIControlStateNormal];
+        [_closeBtn addTarget:self action:@selector(closeBtnClicked:) forControlEvents:UIControlEventTouchUpInside];
+    }
+    return _closeBtn;
+}
+
+@end

--- a/iOS/DoraemonKitDemo/DoraemonKitDemo/Plugin/testGif/function/GIFInfoWindow.h
+++ b/iOS/DoraemonKitDemo/DoraemonKitDemo/Plugin/testGif/function/GIFInfoWindow.h
@@ -1,0 +1,26 @@
+//
+//  GIFInfoWindow.h
+//  DoraemonKitDemo
+//
+//  Created by 宋迪 on 2021/5/17.
+//  Copyright © 2021 yixiang. All rights reserved.
+//
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface GIFInfoWindow : UIWindow
+
++ (GIFInfoWindow *)shareInstance;
+
+- (void)show;
+
+- (void)hide;
+
+- (void)setTimeLast:(NSString *)timeLast;
+- (void)setFrameCount:(NSString *)frameCount;
+- (void)setUrlInfo:(NSString *)UrlInfo;
+- (void)setGifImageSize:(NSString *)GifImageSize;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/iOS/DoraemonKitDemo/DoraemonKitDemo/Plugin/testGif/function/GIFInfoWindow.m
+++ b/iOS/DoraemonKitDemo/DoraemonKitDemo/Plugin/testGif/function/GIFInfoWindow.m
@@ -1,0 +1,123 @@
+//
+//  GIFInfoWindow.m
+//  DoraemonKitDemo
+//
+//  Created by 宋迪 on 2021/5/17.
+//  Copyright © 2021 yixiang. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "GIFInfoWindow.h"
+#import "GIFInfoView.h"
+#import "DoraemonDefine.h"
+
+@interface GIFInfoController: UIViewController
+
+@end
+
+@implementation GIFInfoController
+//- (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
+//    [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
+//    dispatch_async(dispatch_get_main_queue(), ^{
+//        self.view.window.frame = CGRectMake(kDoraemonSizeFrom750_Landscape(100), DoraemonScreenHeight - (size.height < size.width ? size.height : size.width) - kDoraemonSizeFrom750_Landscape(100), size.height, size.width);
+//    });
+//}
+@end
+
+@interface GIFInfoWindow () <GIFInfoViewDelegate>
+
+@property (nonatomic, strong) GIFInfoView *pickInfoView;
+
+@end
+
+@implementation GIFInfoWindow
+
+#pragma mark - Lifecycle
+
++ (GIFInfoWindow *)shareInstance{
+    static dispatch_once_t once;
+    static GIFInfoWindow *instance;
+    dispatch_once(&once, ^{
+        instance = [[GIFInfoWindow alloc] init];
+    });
+    return instance;
+}
+
+- (instancetype)init {
+    
+    if (kInterfaceOrientationPortrait) {
+        self = [super initWithFrame:CGRectMake(kDoraemonSizeFrom750_Landscape(30), DoraemonScreenHeight - kDoraemonSizeFrom750_Landscape(300) - kDoraemonSizeFrom750_Landscape(10) - IPHONE_SAFEBOTTOMAREA_HEIGHT, DoraemonScreenWidth - 2*kDoraemonSizeFrom750_Landscape(30), kDoraemonSizeFrom750_Landscape(300))];
+    } else {
+        self = [super initWithFrame:CGRectMake(kDoraemonSizeFrom750_Landscape(30), DoraemonScreenHeight - kDoraemonSizeFrom750_Landscape(100) - kDoraemonSizeFrom750_Landscape(30) - IPHONE_SAFEBOTTOMAREA_HEIGHT, DoraemonScreenHeight - 2*kDoraemonSizeFrom750_Landscape(30), kDoraemonSizeFrom750_Landscape(100))];
+    }
+    
+    if (self) {
+        #if defined(__IPHONE_13_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0)
+            if (@available(iOS 13.0, *)) {
+                for (UIWindowScene* windowScene in [UIApplication sharedApplication].connectedScenes){
+                    if (windowScene.activationState == UISceneActivationStateForegroundActive){
+                        self.windowScene = windowScene;
+                        break;
+                    }
+                }
+            }
+        #endif
+        self.backgroundColor = [UIColor clearColor];
+        self.windowLevel = UIWindowLevelAlert;
+        if (!self.rootViewController) {
+            self.rootViewController = [[GIFInfoController alloc] init];
+        }
+        
+        GIFInfoView *pickInfoView = [[GIFInfoView alloc] initWithFrame:self.bounds];
+        pickInfoView.delegate = self;
+        [self.rootViewController.view addSubview:pickInfoView];
+        self.pickInfoView = pickInfoView;
+        
+        
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(closePlugin:) name:DoraemonClosePluginNotification object:nil];
+    }
+    return self;
+}
+
+#pragma mark - Public
+
+- (void)show{
+    self.hidden = NO;
+}
+
+- (void)hide{
+    self.hidden = YES;
+}
+
+
+- (void)setTimeLast:(NSString *)timeLast{
+    [self.pickInfoView setTimeLast:timeLast];
+}
+
+- (void)setFrameCount:(NSString *)frameCount{
+    [self.pickInfoView setFrameCount:frameCount];
+}
+
+- (void)setUrlInfo:(NSString *)UrlInfo{
+    [self.pickInfoView setUrlInfo:UrlInfo];
+}
+
+- (void)setGifImageSize:(NSString *)GifImageSize{
+    [self.pickInfoView setGifImageSize:GifImageSize];
+}
+ 
+#pragma mark GIFInfoViewDelegate
+
+- (void)closeBtnClicked:(id)sender onColorPickInfoView:(GIFInfoView *)colorPickInfoView {
+    [[NSNotificationCenter defaultCenter] postNotificationName:DoraemonClosePluginNotification object:nil userInfo:nil];
+}
+
+#pragma mark - Notification
+
+- (void)closePlugin:(NSNotification *)notification{
+    [self hide];
+}
+
+
+@end

--- a/iOS/DoraemonKitDemo/DoraemonKitDemo/Plugin/testGif/function/UIWebViewDemo.h
+++ b/iOS/DoraemonKitDemo/DoraemonKitDemo/Plugin/testGif/function/UIWebViewDemo.h
@@ -1,0 +1,16 @@
+//
+//  UIWebViewDemo.h
+//  DoraemonKitDemo
+//
+//  Created by 宋迪 on 2021/5/18.
+//  Copyright © 2021 yixiang. All rights reserved.
+//
+#import "DoraemonDemoBaseViewController.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface UIWebViewDemo : DoraemonDemoBaseViewController
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/iOS/DoraemonKitDemo/DoraemonKitDemo/Plugin/testGif/function/UIWebViewDemo.m
+++ b/iOS/DoraemonKitDemo/DoraemonKitDemo/Plugin/testGif/function/UIWebViewDemo.m
@@ -1,0 +1,81 @@
+//
+//  UIWebViewDemo.m
+//  DoraemonKitDemo
+//
+//  Created by 宋迪 on 2021/5/18.
+//  Copyright © 2021 yixiang. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "UIWebViewDemo.h"
+#import "UIImageView+GIFProperty.h"
+#import "GIFInfoView.h"
+#import "GIFInfoWindow.h"
+@interface UIWebViewDemo()<UITableViewDelegate, UITableViewDataSource>
+
+@end
+@implementation UIWebViewDemo
+    UIWebView *webview2;
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    
+    self.title = DoraemonDemoLocalizedString(@"UIWebView");
+    webview2 = [[UIWebView alloc] initWithFrame:self.view.frame];
+    [webview2 loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://card.weibo.com/article/m/show/id/2309404225092568618984"]]];
+    //添加长摁识别手势
+    UILongPressGestureRecognizer * longPressed = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(longPressed:)];
+    longPressed.delegate = self;
+    [webview2 addGestureRecognizer:longPressed];
+    [self.view addSubview:webview2];
+}
+//- (void)openUIWebView{
+//    UIViewController *vc = [[UIWebViewDemo alloc] init];
+//    [self.navigationController pushViewController:vc animated:YES];
+//}
+- (void)longPressed:(UITapGestureRecognizer*)recognizer{
+//只在长按手势开始的时候才去获取图片的url
+    if (recognizer.state != UIGestureRecognizerStateBegan) {
+    return;
+    }
+    CGPoint touchPoint = [recognizer locationInView:webview2];
+    NSString *js = [NSString stringWithFormat:@"document.elementFromPoint(%f, %f).src", touchPoint.x, touchPoint.y];
+    NSString *urlToSave = [webview2 stringByEvaluatingJavaScriptFromString:js];
+    if (urlToSave.length == 0) {
+        NSLog(@"获取图片失败");
+        NSString *stringframecount = @"";
+        NSString *stringtimelast = @"获取图片失败";
+        [[GIFInfoWindow shareInstance] setTimeLast:stringtimelast];
+        [[GIFInfoWindow shareInstance] setFrameCount:stringframecount];
+        return;
+    }
+    NSLog(@"获取到图片1地址：%@",urlToSave);
+    NSString *fileURL = urlToSave;
+    NSData *urlData = [NSData dataWithContentsOfURL:[NSURL URLWithString:fileURL]];
+//    NSData *gifData = [NSData dataWithContentsOfFile:[[NSBundle mainBundle] pathForResource:@"variableDuration" ofType:@"gif"]];
+    UIImageView *gifimage = [[UIImageView alloc] init];
+    //获取gif的信息
+    UIImage *imagesize = [UIImage imageWithData:urlData];
+    NSLog(@"===%f===%f",imagesize.size.width,imagesize.size.height);
+    NSString *stringimagesize = [NSString stringWithFormat:@"长：%d，宽：%d",(int)imagesize.size.width,(int)imagesize.size.height];
+    NSString *stringurlinfo = [NSString stringWithFormat:@"图片地址：%@",urlToSave];
+    NSTimeInterval  signSuccessGifImg = [gifimage durationForGifData:urlData];
+    //获取gif执行时间
+    NSInteger GifImgTimelast = [gifimage repeatCountForGifData:urlData];
+    //获取gif的帧数
+    NSInteger gifframecount = [gifimage GifFrameCount:urlData];
+    NSLog(@"%ld",gifframecount);
+    NSLog(@"%f",signSuccessGifImg);
+    NSLog(@"%ld",GifImgTimelast);
+    NSString *stringframecount = [NSString stringWithFormat:@"%ld",gifframecount];
+    stringframecount = [[NSString alloc] initWithFormat:@"帧数：%@",stringframecount];
+    NSString *stringtimelast = [NSString stringWithFormat:@"%f",signSuccessGifImg];
+    stringtimelast = [[NSString alloc] initWithFormat:@"持续时间：%@s",stringtimelast];
+    [[GIFInfoWindow shareInstance] setTimeLast:stringtimelast];
+    [[GIFInfoWindow shareInstance] setFrameCount:stringframecount];
+    [[GIFInfoWindow shareInstance] setUrlInfo:stringurlinfo];
+    [[GIFInfoWindow shareInstance] setGifImageSize:stringimagesize];
+
+    
+}
+
+@end

--- a/iOS/DoraemonKitDemo/DoraemonKitDemo/Plugin/testGif/testA.m
+++ b/iOS/DoraemonKitDemo/DoraemonKitDemo/Plugin/testGif/testA.m
@@ -1,0 +1,32 @@
+//
+//  testA.m
+//  DoraemonKitDemo
+//
+//  Created by 宋迪 on 2021/4/27.
+//  Copyright © 2021 yixiang. All rights reserved.
+//
+
+#import "testA.h"
+#import "UIImageView+GIFProperty.h"
+#import "DoraemonHomeWindow.h"
+#import "GIFInfoWindow.h"
+#import "GIFInfoView.h"
+#import "UIWebViewDemo.h"
+
+@implementation testA
+    UIWebView *webview1;
+- (void)pluginDidLoad {
+    [super viewDidLoad];
+    //[[DoraemonColorPickWindow shareInstance] show];
+    [[GIFInfoWindow shareInstance] show];
+    [[DoraemonHomeWindow shareInstance] hide];
+    NSLog(@"what?");
+    UIViewController *vc = [[UIWebViewDemo alloc] init];
+    [DoraemonHomeWindow openPlugin:vc];
+    
+}
+- (void)openUIWebView{
+    UIViewController *vc = [[UIWebViewDemo alloc] init];
+    [self.navigationController pushViewController:vc animated:YES];
+}
+@end


### PR DESCRIPTION
## GifInfo插件介绍

通过该插件我们可以查看网页中的GIf动图相关信息，比如其持续时间，帧数，尺寸大小，图片url地址等等信息。

## GifInfo插件开发目的

我们在浏览网页的时候往往会遇到一些GIf动图，有时我们想要抓取查看其基本信息，比如是否正常显示，尺寸大小是否合适，持续时间和帧数信息，动图url地址信息等等，这时候都需要把图片保存到本地中再通过动图查看工具进行查看，这样会比较麻烦，因此，本项目开发此插件可以方便的查看图片或者动图的基本信息。

## 插件主要功能

**GIfInfo测试插件位置：**

<div align=center><img src="https://raw.githubusercontent.com/Tju-Bibibo/blog/master/1.png" alt="image-20210530001044398" width="421" height="824" /></div>

**效果如下图展示：**

通过长摁Gif动图可以实现获取其持续时间，帧数，尺寸大小，图片url地址等等信息。

<div align=center><img src="https://raw.githubusercontent.com/Tju-Bibibo/blog/master/2.png" alt="image-20210529234358686" width="421" height="824" /></div>

其中展示的信息有：

- Gif图片持续时间
- Gif图片帧数
- 图片的尺寸大小
- 图片的URL

另外，该插件也可以识别其他非GIf的静态图片，如jpg,png格式，静态图片的持续时间为0，帧数为1。

## 代码说明

项目代码存放路径为

```
/DoraemonKit/iOS/DoraemonKitDemo/DoraemonKitDemo/Plugin/testGif
```

项目代码存放目录为testGif



<div align=center><img src="https://raw.githubusercontent.com/Tju-Bibibo/blog/master/3.png" alt="image-20210530112653699" width="274" height="208" /></div>



其中在DoKitAppDelegate.m文件里面添加了插件GifInfo



<div align=center><img src="https://raw.githubusercontent.com/Tju-Bibibo/blog/master/5.png" alt="image-20210530133212600" width="744" height="158" /></div>

testGif目录里添加了以下文件：

<div align=center><img src="https://raw.githubusercontent.com/Tju-Bibibo/blog/master/4.png" alt="image-20210530133331914" width="350" height="265"/></div>

其中各文件的主要功能如下：

- ./function/GIFInfoView.m 	定义了展示信息框中展示信息的label组件和一些相关信息。
- ./function/GIFInfoWindow.m  	定义了展示信息框组件和一些相关信息。
- ./function/UIWebViewDemo.m 	定义了DoraemonDemoBaseViewController类的子类UIWebViewDemo，定义了一个简单的浏览器，添加了longpressed手势。
- UIImageView+GIFProperty.m 	该文件定义了用来识别GIF图片信息的函数，比如获取持续时间和帧数的函数。
- GifInfo.m 	该插件的主文件。