### PR TITLE
【DoKit&北大开源实践】-【DoKit For Web】-H5任意门

### DIFF
--- a/Web/packages/web/src/plugins/h5-door/ToolH5Door.vue
+++ b/Web/packages/web/src/plugins/h5-door/ToolH5Door.vue
@@ -1,89 +1,194 @@
+
 <template>
   <div class="h5-door">
-    <p>H5传送门</p>
-    <input v-model="url" @click="initial" />
-    <button @click="jumpHtml(url)">Click to Jump</button>
-    <div>
+    <div class="h5-title">
+      <input class="url-ipt" type="search" v-model="url" 
+      placeholder="输入网址，点击右侧跳转" @keyup.enter="jumpHtml(url)">
+      <button class="jump-btn" @click="jumpHtml(url)"> Search</button>
+    </div>
+
+    <div class="hislist-title">
       <p>历史记录</p>
-      <ul>
-        <li
-          style="align-content: center"
-          v-for="his in view_his"
-          :key="his.id"
-          @click="initial"
-        >
-          {{ his.id }} {{ his.content }}
+    </div>
+    
+    <div class="his-part">
+      <ul class="his-table">  
+        <li class="his-item"
+          v-for="(his,id) in view_his" :key="id" >
+          <span class="text-in-li">{{ his.content }} </span>
+          <div>
+            <button class="his-item-btn" @click="jumpHtml(his.content)">载入</button> 
+            <button class="his-item-btn" @click="delHis(id)">清除</button>
+          </div>
         </li>
       </ul>
-      <button @click="clearHistory">清空搜索历史</button>
+    </div>
+    <div class="btm">
+      <p class="clear-tip" v-if="clear">暂无历史记录</p>
+      <button class="clear-btn" v-if="!clear" @click="clearHistory" >清空搜索历史</button>
     </div>
   </div>
 </template>
-<style scoped>
-p {
-  font-family: verdana;
-  font-size: 20px;
-  margin-left: 150px;
-  font-style: italic;
-  font-weight: bold;
-  margin-right: auto;
+
+
+<script>
+let storage = window.localStorage
+
+export default {
+  data(){
+    return{
+      url:null,
+      view_his:this.fetchData(),
+      clear:this.fetchData().length == 0
+    }
+  },
+  watch: {
+    view_his: {
+    handler: function(val, oldVal) {
+      this.storeData(val);
+      if (this.view_his.length == 0){
+        this.clear = true
+      }
+      else{
+        this.clear = false
+      }
+    },
+    deep: true
+  }
+ },
+  methods:{
+    jumpHtml(url){
+      url = url.replace('https','http')
+      if (!url.startsWith('http://')) {
+        url = 'http://' + url
+      }
+
+      let flag = true
+      let len = this.view_his.length
+      for (let i=0; i < len; i++){
+        let his = this.view_his[i]
+        if (his.content == url) {
+          flag = false
+          break
+        }
+      }
+      if (flag){
+        this.addHis(url)
+      }
+      window.open(url)
+    },
+    addHis(url){
+      this.view_his.push({content:url})
+    },
+    delHis(idx){
+      this.view_his.splice(idx, 1)
+
+    },
+    clearHistory(){
+      this.view_his = []
+    },
+    storeData(val){
+      storage.setItem('viewHis', window.JSON.stringify(val))
+      console.log(storage['viewHis'])
+    },
+    fetchData(){
+      return window.JSON.parse(storage.getItem('viewHis') || '[]')
+    }
+  },
 }
-button {
-  font-weight: bold;
-  background-color: white;
-  font-size: small;
-  height: 20px;
-  vertical-align: center;
+</script>
+
+<style lang="less" scoped>
+.h5-title{
   text-align: center;
-  border-radius: 5px;
-  margin-left: 100px;
-  margin: auto;
+  display: flex;
+  justify-content: center;
+  height: inherit;
 }
-div {
-  width: 450px;
-  height: 50px;
-  margin: auto;
-}
-input {
+.url-ipt{
   width: 300px;
-  height: 20px;
+  min-width: 100px;
+  height: 30px;
+  background-color:white;
+  border: solid 2px skyblue;
+  border-top-left-radius: 6px;
+  border-bottom-left-radius: 6px;
+  vertical-align: top;
+  outline: none;
+
+}
+.jump-btn{
+  background-color:skyblue;
+  height: 30px;
+  border: 2px solid skyblue;
+  border-top-right-radius: 6px;
+  border-bottom-right-radius: 6px;
+  color: white;
+  vertical-align: top;
+  
+}
+.clear-tip{
+  font-size: 10px;
+  color: lightgray;
+}
+.hislist-title{
+  text-align: center;
+  margin-top: 30px;
+  font-size: 10px;
+  font-weight: bold;
+}
+.his-part{
+  text-align: center;
+  display: flex;
+  justify-content: center;
+}
+.his-table{
+  margin-bottom: 10px;
+  padding: 10px;
+}
+.his-item{
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  list-style: none;
+  text-align: left;
   background-color: white;
-  font-size: small;
-  border-color: black;
+  border: 1px solid lightgray;
   border-radius: 5px;
+  margin-top: 5px;
+  padding: 3px;
+  width: 350px;  
+  height: 20px;
+  font-size: 15px;  
+  padding: 5px;
+}
+.text-in-li{
+  flex: 0 1 68%;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+}
+.btn-in-li{
+  text-align: center;
+}
+.his-item-btn{
+  min-width: 30px;
+  height: inherit;
+  float: right;
+  margin-left: 10px;
+  background-color:skyblue;
+  border: 2px solid skyblue;
+  border-radius: 5px;
+  color: white;
+}
+.btm{
+  text-align: center;
+}
+.clear-btn{
+  background-color:skyblue;
+  height: 30px;
+  border: 2px solid skyblue;
+  color: white;
+  vertical-align: top;
 }
 </style>
-<script>
-export default {
-  data() {
-    return {
-      url: "输入网址，点击右侧跳转",
-      id: 1,
-      view_his: [],
-    };
-  },
-  methods: {
-    jumpHtml(url) {
-      if (!url.startsWith("http://")) {
-        url = "http://" + url;
-      }
-      this.addHis(url);
-      window.open(url);
-    },
-    initial() {
-      alert(555);
-      if (this.url == "输入网址，点击右侧跳转") {
-        this.url = "";
-      }
-    },
-    addHis(url) {
-      this.view_his.push({ id: this.id, content: url });
-      this.id++;
-    },
-    clearHistory() {
-      this.view_his = [];
-      this.id = 1;
-    },
-  },
-};
-</script>

--- a/Web/packages/web/src/plugins/h5-door/index.js
+++ b/Web/packages/web/src/plugins/h5-door/index.js
@@ -1,10 +1,11 @@
 import HelloWorld from './ToolHelloWorld.vue'
 import {RouterPlugin} from '@dokit/web-core'
+import H5Door from './ToolH5Door.vue'
 
 export default new RouterPlugin({
   nameZh: '任意门',
   name: 'h5-door',
   icon: 'https://pt-starimg.didistatic.com/static/starimg/img/FHqpI3InaS1618997548865.png',
-  component: HelloWorld
+  component: H5Door
 })
 


### PR DESCRIPTION
**功能描述：**
通过输入url地址可以跳转至任意对应页面，同时支持历史记录、数据缓存、单条历史删除/载入等操作

**原理描述：**
核心部分：利用输入框绑定vue中对应的url数据，单击跳转按钮时调用`window.open`打开相应页面
url修正：利用正则化对用户输入的url进行校准，确保能正确跳转，同时支持不输入http/https协议部分
历史记录：利用todolist思想存储用户历史记录，在网页中用`<li>`展示历史记录，同时支持对单条历史的操作
数据缓存：利用`window.localStorage`进行数据缓存，保证用户退出重进时仍然保留之前的历史记录
页面布局：使用flex优化页面布局，防止网址过长带来的影响

**功能截图**
历史为空
![image](https://user-images.githubusercontent.com/58332824/120106821-2af43c00-c191-11eb-926a-f6c760506908.png)

历史记录
![image](https://user-images.githubusercontent.com/58332824/120106883-5a0aad80-c191-11eb-831f-8c9303c34907.png)

页面布局优化
![image](https://user-images.githubusercontent.com/58332824/120106919-80304d80-c191-11eb-808d-eb50327261a3.png)

