### PR TITLE
【DoKit&北大开源实践】-【DoKit For miniapp】- page任意门

### DIFF
--- a/miniapp/src/components/debug/debug.js
+++ b/miniapp/src/components/debug/debug.js
@@ -53,6 +53,11 @@ Component({
                             "title": "数据模拟",
                             "image": img.apimockicon,
                             "type": "apimock"
+                        },
+                        {
+                            "title": "page任意门",
+                            "image": img.h5dooricon,
+                            "type": "pagedoor"
                         }
                     ]
                 }

--- a/miniapp/src/components/debug/debug.wxss
+++ b/miniapp/src/components/debug/debug.wxss
@@ -29,7 +29,7 @@
     text-align: center;
     margin-right:75rpx;
 }
-.card-item:nth-child(4){
+.card-item:nth-child(4n+4){
     margin-right:0;
 }
 .debug-item-image {

--- a/miniapp/src/components/pagedoor/pagedoor.js
+++ b/miniapp/src/components/pagedoor/pagedoor.js
@@ -1,0 +1,153 @@
+// author：zhou-xingxing
+Component({
+  /**
+   * 组件的属性列表
+   */
+  properties: {
+  },
+  /**
+   * 组件的初始数据
+   */
+  data: {
+    parmList: [
+      {
+        key:'',
+        value:''
+      }
+    ],
+    typeList: [
+      {value: 'navigateTo', name: '打开新页面',checked:true},
+      {value: 'redirectTo', name: '页面重定向'},
+      {value: 'reLaunch', name: '重启动'},
+      {value: 'switchTab', name: 'Tab切换'},
+    ],
+    pageList:[],
+    pageUrl:'',
+    goType:'navigateTo',
+  },
+  lifetimes: {
+    attached () {
+        this.setData({
+          pageList:__wxConfig.pages
+        })
+        // console.log(this.data.pageList)
+    }
+},
+  /**
+   * 组件的方法列表
+   */
+  methods: {
+    onGoBack () {
+      this.triggerEvent('toggle', { componentType: 'dokit'})
+    },
+    // page输入框
+    textareaChange(e){
+      this.setData({
+        pageUrl:e.detail.value
+      })
+    },
+    // page选择器
+    bindPickerChange(e) {
+      let url='/'+this.data.pageList[e.detail.value]
+      this.setData({
+        pageUrl:url
+      })
+    },
+    // 修改跳转方式
+    radioChange(e) {
+      this.setData({
+        goType:e.detail.value
+      })
+    },
+    // 增加一组参数
+    addParm(e){
+      let list=this.data.parmList
+      list.push({
+        key:'',
+        value:''
+      })
+      this.setData({
+        parmList:list
+      })
+    },
+    // 输入参数key
+    changeParmkey(e){
+      let idx=e.currentTarget.dataset.index
+      let key = e.detail.value
+      let list=this.data.parmList
+      list[idx].key=key
+      this.setData({
+        parmList:list
+      })
+    },
+    // 输入参数value
+    changeParmValue(e){
+      let idx=e.currentTarget.dataset.index
+      let val = e.detail.value
+      let list=this.data.parmList
+      list[idx].value=val
+      this.setData({
+        parmList:list
+      })
+    },
+    // 拼接路径和参数
+    makeUrl(){
+      let url=this.data.pageUrl
+      let list=this.data.parmList
+      if(!url){
+        wx.showToast({
+          title:'请输入页面路径',
+          icon:"error"
+        })
+        return ""
+      }
+      url=this.data.pageUrl+'?'
+      // 检验参数是否完整
+      for(let i=0;i<list.length;i++){
+        if(list[i].key!=""&&list[i].value!=""){
+          url=url+list[i].key+'='+list[i].value+'&'
+        }
+        else if(list[i].key==""&&list[i].value==""){
+          continue
+        }
+        else{
+          wx.showToast({
+            title:'参数不完整',
+            icon:"error"
+          })
+          return ""
+        }
+      }
+      return url
+    },
+    // 页面跳转
+    goPage(){
+      let url=this.makeUrl()
+      let type=this.data.goType
+      if(url==""){
+        return
+      }
+      // switchTab不支持queryString
+      if(type=='switchTab'){
+          let pos=0
+          for(;pos<url.length;pos++){
+            if(url[pos]=='?'){
+              break;
+            }
+          }
+          url=url.substring(0,pos)
+      }
+      console.log("页面路径：",url)
+      // 跳转实现
+      wx[type]({
+        url: url,
+        fail:(e)=>{
+          wx.showModal({
+            title:'跳转失败',
+            content: '错误信息：'+e.errMsg,
+          })
+        }
+      })
+    },
+  }
+})

--- a/miniapp/src/components/pagedoor/pagedoor.json
+++ b/miniapp/src/components/pagedoor/pagedoor.json
@@ -1,0 +1,6 @@
+{
+  "component": true,
+  "usingComponents": {
+    "back": "../../components/back/back"
+  }
+}

--- a/miniapp/src/components/pagedoor/pagedoor.wxml
+++ b/miniapp/src/components/pagedoor/pagedoor.wxml
@@ -1,0 +1,53 @@
+<view class="pagedoor-page">
+
+  <view class="panel-box">
+    <view class="big-label">页面路径</view>   
+    <view class="area-box">
+        <textarea  class="url-box"  placeholder="请输入page绝对路径，以/开头" maxlength="140" placeholder-class="url-paceholder-text"
+        bindinput="textareaChange" value="{{pageUrl}}">
+        </textarea>
+    </view>
+    <picker bindchange="bindPickerChange" value="{{index}}" range="{{pageList}}">
+      <view class="pagedoor-button">
+        自动填写
+      </view>
+    </picker>    
+  </view>
+
+  <view class="panel-box">
+    <view class="big-label">参数列表</view>
+    <block wx:for="{{parmList}}">
+      <view class="parm-list">
+        <view class="parm-box">
+          <label>key：</label>
+          <input class="input-box" value="{{item.key}}" bindinput='changeParmkey' data-index='{{index}}'></input>
+        </view>
+        <view class="parm-box">
+          <label>value：</label>
+          <input class="input-box" value="{{item.value}}" bindinput='changeParmValue' data-index='{{index}}'></input>
+        </view>
+      </view>
+    </block>
+    <view class="pagedoor-button" bindtap='addParm'>
+      添加参数
+    </view>
+  </view>
+
+  <view class="panel-box">
+    <view class="big-label">跳转方式</view>
+    <view>
+      <radio-group bindchange="radioChange">
+        <view wx:for="{{typeList}}" class="radio-group">         
+            <radio value="{{item.value}}" checked="{{item.checked}}"></radio> 
+            <text>{{item.name}}</text>
+        </view>
+      </radio-group>
+    </view>
+  </view>
+  
+  <button class="go-page-button" bindtap="goPage" size="default" type="" plain="default" hover-stop-propagation="false">
+      点击跳转
+  </button>
+</view>
+
+<back top="80%" bindreturn="onGoBack"></back>

--- a/miniapp/src/components/pagedoor/pagedoor.wxss
+++ b/miniapp/src/components/pagedoor/pagedoor.wxss
@@ -1,0 +1,74 @@
+.pagedoor-page {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  width: 100%;
+  height:100vh;
+  background-color: white;
+  z-index: 9998;
+}
+.pagedoor-page .url-box{
+  height: 358rpx;
+  width: 100%;
+  position: absolute;
+  left: 0;
+  top: 0;
+  z-index: 1;
+}
+.pagedoor-page .area-box{
+  width: 98%;
+  margin: 0 auto;
+  box-sizing: border-box;
+  border: 1px solid #efefef;
+  height: 358rpx;
+  position: relative;
+}
+.url-box .url-paceholder-text{
+  font-size: 32rpx;
+  color: #BEBEBE;
+}
+.pagedoor-page .go-page-button{
+  margin-top: 200rpx;
+  margin-bottom: 100rpx;
+  width: 600rpx;
+  height: 100rpx;
+  background: #337CC4;
+  border: 0;
+  color:#ffffff;
+}
+.pagedoor-page .radio-group{
+  margin: 20rpx 10rpx;
+}
+.panel-box{
+  margin-bottom: 40rpx ;
+}
+.big-label{
+  font-size: 40rpx;
+  color:#337CC4;
+  margin: 20rpx 0;
+}
+.parm-list{
+  display: flex;
+  justify-content: space-around;
+}
+.parm-box{
+  display: flex;
+  justify-content: center;
+  margin: 10rpx 0;
+}
+.input-box{
+  background-color:whitesmoke;
+  width: 250rpx;
+  border: 1rpx solid black;
+}
+.pagedoor-button{
+  display: flex;
+  justify-content: center;
+  align-items:center;
+  margin:40rpx auto;
+  width: 200rpx;
+  height: 70rpx;
+  color:whitesmoke;
+  background-color:#337CC4;
+}

--- a/miniapp/src/index/index.json
+++ b/miniapp/src/index/index.json
@@ -8,6 +8,7 @@
     "storage": "../components/storage/storage",
     "h5door": "../components/h5door/h5door",
     "httpinjector": "../components/httpinjector/httpinjector",
-    "apimock": "../components/apimock/apimock"
+    "apimock": "../components/apimock/apimock",
+    "pagedoor":"../components/pagedoor/pagedoor"
   }
 }

--- a/miniapp/src/index/index.wxml
+++ b/miniapp/src/index/index.wxml
@@ -23,6 +23,7 @@
     <h5door wx:if="{{ curCom === 'h5door' }}" bindtoggle="tooggleComponent"></h5door>
     <httpinjector wx:if="{{ curCom === 'httpinjector' }}" bindtoggle="tooggleComponent"></httpinjector>
     <apimock wx:if="{{ curCom === 'apimock' }}" bindtoggle="tooggleComponent" projectId="{{ projectId }}"></apimock>
+    <pagedoor wx:if="{{ curCom === 'pagedoor' }}" bindtoggle="tooggleComponent"></pagedoor>
 </block>
 <block wx:else>
     <cover-image


### PR DESCRIPTION
**功能描述：**

允许用户很方便的测试以不同方式并携带任意参数进入某一页面的效果
- 通过自动填写或手动输入的方式确定页面路径
- 支持动态添加参数
- 支持四种路由方式（`navigateTo` 、`redirectTo`、`reLaunch`、`switchTab` ）

**实现原理：**

通过`__wxConfig` 自动获取项目全局的页面路径，将路径与参数拼接后调用官方API实现不同方式路由
（注：由于`wx.switchTab` 不支持携带参数，因此使用Tab切换方式时输入的参数会被忽略）

**功能截图：**
![微信图片_20210531100711](https://user-images.githubusercontent.com/39901105/120144386-5ff5a280-c214-11eb-9c1a-46456bf6b71a.jpg)
![微信图片_20210531133640](https://user-images.githubusercontent.com/39901105/120144884-499c1680-c215-11eb-8041-72126ebd41ea.jpg)

