### PR TITLE
【DoKit&北大开源实践】-【DoKit For Web】- 资源查看

### DIFF
--- a/Web/packages/web/src/plugins/resources/js/resources.js
+++ b/Web/packages/web/src/plugins/resources/js/resources.js
@@ -58,7 +58,7 @@ export const getResourceEntries = function(callback) {
         arr.forEach((entry) => {
             let entryType = ResourceEntriesMap['other']
             Resource_METHODS.forEach((type) => {
-                if (entry.initiatorType === type || (type === "img" && entry.initiatorType === "css" && isImg(entry.name)) || (type === "css" && isCss(entry.name))) {
+                if (entry.initiatorType === type || (type === "img" && entry.initiatorType === "css" && isImg(entry.name)) || (type === "css" && entry.initiatorType === "link" && isCss(entry.name))) {
                     entryType = ResourceEntriesMap[type];
                 }
             })


### PR DESCRIPTION
修改了函数getResourceEntries，防止css页面中显示xmlhttprequest类型的css资源