### PR TITLE
fix(iOS): fishhook crash

### DIFF
--- a/iOS/DoraemonKit/Src/Core/Util/fishhook/doraemon_fishhook.c
+++ b/iOS/DoraemonKit/Src/Core/Util/fishhook/doraemon_fishhook.c
@@ -7,6 +7,7 @@
 
 #include "doraemon_fishhook.h"
 
+#include <assert.h>
 #include <dlfcn.h>
 #include <stdbool.h>
 #include <stdlib.h>
@@ -96,10 +97,35 @@ static void doraemon_perform_rebinding_with_section(struct doraemon_rebindings_e
   const bool isDataConst = strcmp(section->segname, "__DATA_CONST") == 0;
   uint32_t *indirect_symbol_indices = indirect_symtab + section->reserved1;
   void **indirect_symbol_bindings = (void **)((uintptr_t)slide + section->addr);
-  vm_prot_t oldProtection = VM_PROT_READ;
+  vm_prot_t oldProtection = VM_PROT_NONE;
+  vm_address_t vmAddress = (vm_address_t)indirect_symbol_bindings;
+  // https://opensource.apple.com/source/xnu/xnu-7195.141.2/osfmk/vm/vm_user.c.auto.html
+  // OUT argument, but init with zero to eliminate `Variable 'vmSize' may be uninitialized when used here` warning
+  vm_size_t vmSize = 0;
   if (isDataConst) {
-    oldProtection = doraemon_get_protection(rebindings);
-    mprotect(indirect_symbol_bindings, section->size, PROT_READ | PROT_WRITE);
+    memory_object_name_t object;
+#ifdef __LP64__
+    mach_msg_type_number_t count = VM_REGION_BASIC_INFO_COUNT_64;
+    vm_region_basic_info_data_64_t vmRegionBasicInfoData;
+    kern_return_t kernelReturn = vm_region_64(mach_task_self(), &vmAddress, &vmSize, VM_REGION_BASIC_INFO_64, (vm_region_info_t)&vmRegionBasicInfoData, &count, &object);
+#else
+    mach_msg_type_number_t count = VM_REGION_BASIC_INFO_COUNT;
+    vm_region_basic_info_data_t vmRegionBasicInfoData;
+    kern_return_t kernelReturn = vm_region(mach_task_self(), &vmAddress, &vmSize, VM_REGION_BASIC_INFO, (vm_region_info_t)&vmRegionBasicInfoData, &count, object);
+#endif
+    if (__builtin_expect(kernelReturn == KERN_SUCCESS, true)) {
+      oldProtection = vmRegionBasicInfoData.protection;
+    } else {
+      assert(false && "vm_region() failure.");
+          
+      return;
+    }
+    kernelReturn = vm_protect(mach_task_self(), vmAddress, vmSize, false, oldProtection | VM_PROT_WRITE);
+    if (__builtin_expect(kernelReturn != KERN_SUCCESS, false)) {
+      assert(false && "vm_protect() failure.");
+          
+      return;
+    }
   }
   for (uint i = 0; i < section->size / sizeof(void *); i++) {
     uint32_t symtab_index = indirect_symbol_indices[i];
@@ -128,17 +154,8 @@ static void doraemon_perform_rebinding_with_section(struct doraemon_rebindings_e
   symbol_loop:;
   }
   if (isDataConst) {
-    int protection = 0;
-    if (oldProtection & VM_PROT_READ) {
-      protection |= PROT_READ;
-    }
-    if (oldProtection & VM_PROT_WRITE) {
-      protection |= PROT_WRITE;
-    }
-    if (oldProtection & VM_PROT_EXECUTE) {
-      protection |= PROT_EXEC;
-    }
-    mprotect(indirect_symbol_bindings, section->size, protection);
+    kern_return_t kernelReturn = vm_protect(mach_task_self(), vmAddress, vmSize, false, oldProtection);
+    assert(kernelReturn == KERN_SUCCESS && "vm_protect() failure.");
   }
 }
 


### PR DESCRIPTION
Use vm_region() get protection of `__DATA[_CONST] -> __la_symbol_ptr` section