### PR TITLE
fix:[Android] Fix amap crash and adapt amap privacy compliance interface

### DIFF
--- a/Android/app/src/main/java/com/didichuxing/doraemondemo/amap/AMapRouterFragment.kt
+++ b/Android/app/src/main/java/com/didichuxing/doraemondemo/amap/AMapRouterFragment.kt
@@ -28,7 +28,7 @@ class AMapRouterFragment : CommBaseFragment() {
     private var mDefaultNaviListener: DefaultNaviListener? = null
     private lateinit var mAmap: AMap
     private lateinit var mapView: MapView
-    private lateinit var mAMapNavi: AMapNavi
+    private var mAMapNavi: AMapNavi? = null
     private val mStartPoint = NaviLatLng(30.29659, 120.081127)
     private val mEndPoint = NaviLatLng(30.296793, 121.07527)
     override fun initActivityTitle(): String {
@@ -147,19 +147,27 @@ class AMapRouterFragment : CommBaseFragment() {
         //aMap.getUiSettings().setMyLocationButtonEnabled(true);设置默认定位按钮是否显示，非必需设置。
         // 设置为true表示启动显示定位蓝点，false表示隐藏定位蓝点并不进行定位，默认是false。
         mAmap.isMyLocationEnabled = true
-        //规划路径
-        mAMapNavi = AMapNavi.getInstance(activity?.application)
+        //确保调用SDK任何接口前先调用更新隐私合规updatePrivacyShow、updatePrivacyAgree两个接口并且参数值都为true，若未正确设置有崩溃风险
+        //官方文档：https://lbs.amap.com/api/android-navi-sdk/guide/create-project/configuration-considerations#t3
+        NaviSetting.updatePrivacyShow(context, true, true)
+        NaviSetting.updatePrivacyAgree(context, true)
+        try {
+            //规划路径
+            mAMapNavi = AMapNavi.getInstance(activity?.application)
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
         val startList = mutableListOf<NaviLatLng>()
         startList.add(mStartPoint)
         val endList = mutableListOf<NaviLatLng>()
         endList.add(mEndPoint)
-        mAMapNavi.calculateDriveRoute(
+        mAMapNavi?.calculateDriveRoute(
             startList,
             endList,
             null,
             PathPlanningStrategy.DRIVING_MULTIPLE_ROUTES_DEFAULT
         )
-        mAMapNavi.addAMapNaviListener(activity?.application?.let {
+        mAMapNavi?.addAMapNaviListener(activity?.application?.let {
             mDefaultNaviListener = DefaultNaviListener(mAmap, mAMapNavi, it)
             mDefaultNaviListener
         })

--- a/Android/app/src/main/java/com/didichuxing/doraemondemo/amap/DefaultNaviListener.kt
+++ b/Android/app/src/main/java/com/didichuxing/doraemondemo/amap/DefaultNaviListener.kt
@@ -20,7 +20,7 @@ import io.reactivex.disposables.Disposable
  * 修订历史：
  * ================================================
  */
-class DefaultNaviListener(val mAMap: AMap, val mAMapNavi: AMapNavi, val context: Context) :
+class DefaultNaviListener(val mAMap: AMap, val mAMapNavi: AMapNavi?, val context: Context) :
     AMapNaviListener {
 //    private var mNaviRouteOverlay: NaviRouteOverlay? = null
 //
@@ -148,11 +148,11 @@ class DefaultNaviListener(val mAMap: AMap, val mAMapNavi: AMapNavi, val context:
     override fun onCalculateRouteSuccess(result: AMapCalcRouteResult?) {
 //        LogHelper.i(TAG, "mAMapNavi.naviPath.coordList===>${mAMapNavi.naviPath.coordList.size}")
 //        RouterManager.mCoordList = mAMapNavi.naviPath.coordList
-        val naviRouteOverlay = NaviRouteOverlay(mAMap, mAMapNavi.naviPath, context)
+        val naviRouteOverlay = NaviRouteOverlay(mAMap, mAMapNavi?.naviPath, context)
         naviRouteOverlay.setShowDefaultLineArrow(true)
         naviRouteOverlay.addToMap()
 //        naviRouteOverlay.removeFromMap()
-        mAMapNavi.setEmulatorNaviSpeed(10)
+        mAMapNavi?.setEmulatorNaviSpeed(10)
         /**
          * 	CRUISE
         巡航模式（数值：3）
@@ -163,7 +163,7 @@ class DefaultNaviListener(val mAMap: AMap, val mAMapNavi: AMapNavi, val context:
         NONE
         未开始导航（数值：-1）
          */
-        mAMapNavi.startNavi(NaviType.GPS)
+        mAMapNavi?.startNavi(NaviType.GPS)
 
 //        disp = MockGPSTaskManager.startGpsMockTask(mAMapNavi.naviPath)?.subscribe()
     }

--- a/Android/dokit/src/main/java/com/didichuxing/doraemonkit/kit/lbs/route/AMapRealNavMockView.kt
+++ b/Android/dokit/src/main/java/com/didichuxing/doraemonkit/kit/lbs/route/AMapRealNavMockView.kt
@@ -11,11 +11,11 @@ import android.widget.SeekBar
 import android.widget.TextView
 import androidx.core.view.children
 import com.amap.api.navi.AMapNavi
+import com.amap.api.navi.NaviSetting
 import com.didichuxing.doraemonkit.DoKit
 import com.didichuxing.doraemonkit.R
 import com.didichuxing.doraemonkit.kit.core.AbsDokitView
 import com.didichuxing.doraemonkit.kit.core.DokitViewLayoutParams
-import com.didichuxing.doraemonkit.kit.core.DokitViewManager
 import com.didichuxing.doraemonkit.kit.gpsmock.GpsMockManager
 import com.didichuxing.doraemonkit.util.ConvertUtils
 import com.didichuxing.doraemonkit.util.LogHelper
@@ -40,7 +40,15 @@ class AMapRealNavMockView : AbsDokitView() {
     private var mAMapNavi: AMapNavi? = null
 
     override fun onCreate(context: Context?) {
-        mAMapNavi = AMapNavi.getInstance(activity.application)
+        //确保调用SDK任何接口前先调用更新隐私合规updatePrivacyShow、updatePrivacyAgree两个接口并且参数值都为true，若未正确设置有崩溃风险
+        //官方文档：https://lbs.amap.com/api/android-navi-sdk/guide/create-project/configuration-considerations#t3
+        NaviSetting.updatePrivacyShow(context, true, true)
+        NaviSetting.updatePrivacyAgree(context, true)
+        try {
+            mAMapNavi = AMapNavi.getInstance(activity.application)
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
     }
 
     override fun onCreateView(context: Context?, rootView: FrameLayout?): View {


### PR DESCRIPTION
高德地图相关sdk升级到最新版本后需要强制添加隐私合规接口否则会导致崩溃
文档地址：https://lbs.amap.com/api/android-navi-sdk/guide/create-project/configuration-considerations#t3
Dokit 中涉及到的页面
1.  app/高德路径规划
2. dokit/实时导航悬浮窗