### PR TITLE
Fix NPE in DokitMoreFragment when data is null

### DIFF
--- a/Android/dokit/src/main/java/com/didichuxing/doraemonkit/kit/toolpanel/DokitMoreFragment.kt
+++ b/Android/dokit/src/main/java/com/didichuxing/doraemonkit/kit/toolpanel/DokitMoreFragment.kt
@@ -53,7 +53,15 @@ class DokitMoreFragment : BaseFragment() {
                     it,
                     MorePageGroupBean::class.java
                 )
-                initView(convertGroup2normalItem(morePageGroupBean.data.group))
+
+                val groups = morePageGroupBean
+                    ?.data
+                    ?.group                
+                if (groups.isNullOrEmpty()) {
+                    initView(convertGroup2normalItem(createDefaultGroups()))
+                } else {
+                    initView(convertGroup2normalItem(groups))
+                }
             }, {
                 initView(convertGroup2normalItem(createDefaultGroups()))
             })


### PR DESCRIPTION
### Problem
When the request to DOKIT_MORE_PAGE_URL fails (e.g. HTTP 503 or DNS issue),
the response body may be null or invalid.

The current implementation assumes `morePageGroupBean.data` is non-null,
which can cause a crash:

java.lang.NullPointerException: morePageGroupBean.data must not be null

### Solution
- Add null safety checks for `data` and `group`
- Fallback to default groups when data is invalid
- Prevent app crash in unstable network environments

### Notes
This API depends on a remote service which may be unreachable in some regions,
so defensive handling is necessary.